### PR TITLE
Remove "translation unfinished" everywhere

### DIFF
--- a/resources/translations/sddm-conf_ca.ts
+++ b/resources/translations/sddm-conf_ca.ts
@@ -6,81 +6,81 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Inici de sessió automàtic</translation>
+        <translation>Inici de sessió automàtic</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Nom d&apos;usuari per a la sessió d&apos;inici automàtic</translation>
+        <translation>Nom d&apos;usuari per a la sessió d&apos;inici automàtic</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Indiqueu si sddm s&apos;ha de tornar a connectar automàticament a les sessions al sortir</translation>
+        <translation>Indiqueu si sddm s&apos;ha de tornar a connectar automàticament a les sessions al sortir</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Nom del fitxer de sessió per a l&apos;inici automàtic (si està buit, proveu l&apos;última sessió)</translation>
+        <translation>Nom del fitxer de sessió per a l&apos;inici automàtic (si està buit, proveu l&apos;última sessió)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">General</translation>
+        <translation>General</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Ordre de reinici</translation>
+        <translation>Ordre de reinici</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Si la propietat s&apos;estableix a &quot;cap&quot;, el bloqueig numèric no es canviarà
+        <translation>Si la propietat s&apos;estableix a &quot;cap&quot;, el bloqueig numèric no es canviarà
 NOTA: Actualment s&apos;ignora si l&apos;inici de sessió automàtic està habilitat.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Estat inicial del bloqueig numèric. Pot estar encès, desactivat o cap.</translation>
+        <translation>Estat inicial del bloqueig numèric. Pot estar encès, desactivat o cap.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Mòdul del mètode d&apos;entrada</translation>
+        <translation>Mòdul del mètode d&apos;entrada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Ordre d&apos;aturada</translation>
+        <translation>Ordre d&apos;aturada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Tema</translation>
+        <translation>Tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Camí al directori del tema</translation>
+        <translation>Camí al directori del tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">per sobre del qual els avatars es desactivaran
+        <translation>per sobre del qual els avatars es desactivaran
 tret que estigui activat explícitament amb EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Nom del tema actual</translation>
+        <translation>Nom del tema actual</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Tema del cursor a la pantalla d&apos;inici de sessió</translation>
+        <translation>Tema del cursor a la pantalla d&apos;inici de sessió</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
@@ -90,32 +90,32 @@ tret que estigui activat explícitament amb EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Nombre d&apos;usuaris a utilitzar com a llindar</translation>
+        <translation>Nombre d&apos;usuaris a utilitzar com a llindar</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Previsualització</translation>
+        <translation>Previsualització</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Habilita la visualització d&apos;avatars d&apos;usuari personalitzats</translation>
+        <translation>Habilita la visualització d&apos;avatars d&apos;usuari personalitzats</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Els fitxers s&apos;han d&apos;anomenar &lt;nom d&apos;usuari&gt;.face.icon</translation>
+        <translation>Els fitxers s&apos;han d&apos;anomenar &lt;nom d&apos;usuari&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Usuaris</translation>
+        <translation>Usuaris</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">$PATH predeterminada per als usuaris que han iniciat la sessió</translation>
+        <translation>$PATH predeterminada per als usuaris que han iniciat la sessió</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ tret que estigui activat explícitament amb EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Llista separada per comes d&apos;usuaris que no s&apos;han de llistar</translation>
+        <translation>Llista separada per comes d&apos;usuaris que no s&apos;han de llistar</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Mínims identificadors d&apos;usuari per als usuaris mostrats</translation>
+        <translation>Mínims identificadors d&apos;usuari per als usuaris mostrats</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Màxims identificadors d&apos;usuari per als usuaris mostrats</translation>
+        <translation>Màxims identificadors d&apos;usuari per als usuaris mostrats</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Recorda la sessió de l&apos;últim usuari connectat correctament</translation>
+        <translation>Recorda la sessió de l&apos;últim usuari connectat correctament</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Recorda l&apos;últim usuari que ha iniciat sessió amb èxit</translation>
+        <translation>Recorda l&apos;últim usuari que ha iniciat sessió amb èxit</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Habilita l&apos;escalat automàtic d&apos;alta resolució de Qt</translation>
+        <translation>Habilita l&apos;escalat automàtic d&apos;alta resolució de Qt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Camí a un script a executar en iniciar la sessió de l&apos;escriptori</translation>
+        <translation>Camí a un script a executar en iniciar la sessió de l&apos;escriptori</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Camí al fitxer de registre de la sessió de l&apos;usuari</translation>
+        <translation>Camí al fitxer de registre de la sessió de l&apos;usuari</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Directori que conté les sessions Wayland disponibles</translation>
+        <translation>Directori que conté les sessions Wayland disponibles</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ tret que estigui activat explícitament amb EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Camí al binari del servidor X</translation>
+        <translation>Camí al binari del servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Arguments passats a la invocació del servidor X</translation>
+        <translation>Arguments passats a la invocació del servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Directori que conté les sessions X disponibles</translation>
+        <translation>Directori que conté les sessions X disponibles</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Camí a un script a executar en iniciar el servidor de visualització</translation>
+        <translation>Camí a un script a executar en iniciar el servidor de visualització</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Camí a un script a executar en aturar el servidor de visualització</translation>
+        <translation>Camí a un script a executar en aturar el servidor de visualització</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Camí al binari xauth</translation>
+        <translation>Camí al binari xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Camí al binari de Xephyr</translation>
+        <translation>Camí al binari de Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Camí al fitxer Xauthority</translation>
+        <translation>Camí al fitxer Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Fitxer</translation>
+        <translation>Fitxer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ tret que estigui activat explícitament amb EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Editor de la configuració de SDDM</translation>
+        <translation>Editor de la configuració de SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_cs.ts
+++ b/resources/translations/sddm-conf_cs.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatické přihlášení</translation>
+        <translation>Automatické přihlášení</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Uživatelské jméno pro automaticky přihlášené sezení</translation>
+        <translation>Uživatelské jméno pro automaticky přihlášené sezení</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Zda se má sddm automaticky přihlásit zpět k sezením po jejich ukončení</translation>
+        <translation>Zda se má sddm automaticky přihlásit zpět k sezením po jejich ukončení</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Název souboru se sezením pro automaticky přihlášené sezení (pokud je prázdný, zkusit poslední přihlášení)</translation>
+        <translation>Název souboru se sezením pro automaticky přihlášené sezení (pokud je prázdný, zkusit poslední přihlášení)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Obecné</translation>
+        <translation>Obecné</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Příkaz pro restart</translation>
+        <translation>Příkaz pro restart</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Pokud je vlastnost nastavena na žádné, stav numerické klávesnice nebude změněn
+        <translation>Pokud je vlastnost nastavena na žádné, stav numerické klávesnice nebude změněn
 POZN.: V současnosti je ignorováno, pokud je zapnuté automatické přihlašování.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Počáteční stav zámku klávesnice (NumLock). Může být zapnuta, vypnuta nebo žádný.</translation>
+        <translation>Počáteční stav zámku klávesnice (NumLock). Může být zapnuta, vypnuta nebo žádný.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Modul metody zadávání</translation>
+        <translation>Modul metody zadávání</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Příkaz pro zastavení</translation>
+        <translation>Příkaz pro zastavení</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Motiv vzhledu</translation>
+        <translation>Motiv vzhledu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Popis umístění složky s motivy vzhledu</translation>
+        <translation>Popis umístění složky s motivy vzhledu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">nad který jsou avataři vypnutí
+        <translation>nad který jsou avataři vypnutí
 pokud nejsou výslovně zapnutí pomocí EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Název stávajícího motivu vzhledu</translation>
+        <translation>Název stávajícího motivu vzhledu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Uživatelsky určený motiv vzhledu uvítací obrazovky</translation>
+        <translation>Uživatelsky určený motiv vzhledu uvítací obrazovky</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Globální složka pro avatary uživatelů</translation>
+        <translation>Globální složka pro avatary uživatelů</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Počet uživatelů, který použít jako práh</translation>
+        <translation>Počet uživatelů, který použít jako práh</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Náhled</translation>
+        <translation>Náhled</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Zapnout zobrazování uživatelsky určených avatarů uživatelů</translation>
+        <translation>Zapnout zobrazování uživatelsky určených avatarů uživatelů</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Soubory by měly mít názvy &lt;username&gt;.face.icon</translation>
+        <translation>Soubory by měly mít názvy &lt;username&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Uživatelé</translation>
+        <translation>Uživatelé</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Výchozí obsah proměnné $PATH pro přihlašující se uživatele</translation>
+        <translation>Výchozí obsah proměnné $PATH pro přihlašující se uživatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ pokud nejsou výslovně zapnutí pomocí EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Čárkou oddělovaný seznam uživatelů, kteří nebudou vypsáni</translation>
+        <translation>Čárkou oddělovaný seznam uživatelů, kteří nebudou vypsáni</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Nejnižší identif. uživatele pro zobrazované uživatele</translation>
+        <translation>Nejnižší identif. uživatele pro zobrazované uživatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Nejvyšší identif. uživatele pro zobrazované uživatele</translation>
+        <translation>Nejvyšší identif. uživatele pro zobrazované uživatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Pamatovat si relaci naposledy úspěšně přihlášeného uživatele</translation>
+        <translation>Pamatovat si relaci naposledy úspěšně přihlášeného uživatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Pamatovat si naposledy úspěšně přihlášeného uživatele</translation>
+        <translation>Pamatovat si naposledy úspěšně přihlášeného uživatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Zapnout automatické škálování HDPI v rámci Qt</translation>
+        <translation>Zapnout automatické škálování HDPI v rámci Qt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Popis umístění skriptu který vykonat při spouštění relace plochy</translation>
+        <translation>Popis umístění skriptu který vykonat při spouštění relace plochy</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Popis umístění souboru se záznamem událostí relace uživatele</translation>
+        <translation>Popis umístění souboru se záznamem událostí relace uživatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Složka obsahující Wayland relace, které jsou k dispozici</translation>
+        <translation>Složka obsahující Wayland relace, které jsou k dispozici</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ pokud nejsou výslovně zapnutí pomocí EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Popis umístění spustitelného souboru s X serverem</translation>
+        <translation>Popis umístění spustitelného souboru s X serverem</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumenty předané vyvolání X serveru</translation>
+        <translation>Argumenty předané vyvolání X serveru</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Složka obsahující X relace k dispozici</translation>
+        <translation>Složka obsahující X relace k dispozici</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Popis umístění skriptu který vykonat při spouštění zobrazovacího serveru</translation>
+        <translation>Popis umístění skriptu který vykonat při spouštění zobrazovacího serveru</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Popis umístění skriptu který vykonat při zastavování zobrazovacího serveru</translation>
+        <translation>Popis umístění skriptu který vykonat při zastavování zobrazovacího serveru</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Popis umístění spouštěcího souboru s xauth</translation>
+        <translation>Popis umístění spouštěcího souboru s xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Popis umístění spouštěcího souboru s Xephyr</translation>
+        <translation>Popis umístění spouštěcího souboru s Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Popis umístění souboru Xauthority</translation>
+        <translation>Popis umístění souboru Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Soubor</translation>
+        <translation>Soubor</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ pokud nejsou výslovně zapnutí pomocí EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Editor nastavení pro SDDM</translation>
+        <translation>Editor nastavení pro SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_de.ts
+++ b/resources/translations/sddm-conf_de.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatische Anmeldung</translation>
+        <translation>Automatische Anmeldung</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Benutzername für automatische Anmeldung</translation>
+        <translation>Benutzername für automatische Anmeldung</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Soll SDDM beim Verlassen eine automatische Neuanmeldung durchführen</translation>
+        <translation>Soll SDDM beim Verlassen eine automatische Neuanmeldung durchführen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Name der Session-Datei für die automatische Anmeldung (falls leer versuche letzte Anmeldung)</translation>
+        <translation>Name der Session-Datei für die automatische Anmeldung (falls leer versuche letzte Anmeldung)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Allgemein</translation>
+        <translation>Allgemein</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Neustart-Befehl</translation>
+        <translation>Neustart-Befehl</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Wenn die Einstellung auf Nichts steht, wird der NumLock-Zustand nicht geändert
+        <translation>Wenn die Einstellung auf Nichts steht, wird der NumLock-Zustand nicht geändert
 Anmerkung: Wird bei automatischer Anmeldung ignoriert.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">NumLock-Anfangszustand. Möglich sind Ein, Aus oder Nichts.</translation>
+        <translation>NumLock-Anfangszustand. Möglich sind Ein, Aus oder Nichts.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Eingabemethodenmodul</translation>
+        <translation>Eingabemethodenmodul</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Halt Befehl</translation>
+        <translation>Halt Befehl</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Thema</translation>
+        <translation>Thema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Verzeichnispfad des Themas</translation>
+        <translation>Verzeichnispfad des Themas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">obige Avatare sind deaktiviert
+        <translation>obige Avatare sind deaktiviert
 außer explizit aktiviert mit EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Name des aktuellen Themas</translation>
+        <translation>Name des aktuellen Themas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Cursor-Thema im Anmeldefenster</translation>
+        <translation>Cursor-Thema im Anmeldefenster</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Globales Verzeichnis für Benutzer-Avatare</translation>
+        <translation>Globales Verzeichnis für Benutzer-Avatare</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Benutzeranzahl als Schwelle</translation>
+        <translation>Benutzeranzahl als Schwelle</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Vorschau</translation>
+        <translation>Vorschau</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Anzeige von individuellen Benutzer-Avataren aktivieren</translation>
+        <translation>Anzeige von individuellen Benutzer-Avataren aktivieren</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Die Dateien sollten &lt;Benutzername&gt;.face.icon heißen</translation>
+        <translation>Die Dateien sollten &lt;Benutzername&gt;.face.icon heißen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Benutzer</translation>
+        <translation>Benutzer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Standard-$PATH für angemeldete Benutzer</translation>
+        <translation>Standard-$PATH für angemeldete Benutzer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ außer explizit aktiviert mit EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Komma-getrennte Liste von Benutzern, die nicht aufgelistet werden sollten</translation>
+        <translation>Komma-getrennte Liste von Benutzern, die nicht aufgelistet werden sollten</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">kleinste UID für die gelisteten Benutzer</translation>
+        <translation>kleinste UID für die gelisteten Benutzer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">höchste UID der gelisteten Benutzer</translation>
+        <translation>höchste UID der gelisteten Benutzer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Sitzung des zuletzt erfolgreich angemeldeten Benutzers merken</translation>
+        <translation>Sitzung des zuletzt erfolgreich angemeldeten Benutzers merken</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Zuletzt erfolgreich angemeldeten Benutzer merken</translation>
+        <translation>Zuletzt erfolgreich angemeldeten Benutzer merken</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Aktiviere automatische high-DPI Skalierung</translation>
+        <translation>Aktiviere automatische high-DPI Skalierung</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Der Dateipfad zum Script, das nach der Anmeldung ausgeführt wird</translation>
+        <translation>Der Dateipfad zum Script, das nach der Anmeldung ausgeführt wird</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Pfad zur Benutzer-Sitzungsprotokolldatei</translation>
+        <translation>Pfad zur Benutzer-Sitzungsprotokolldatei</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Verzeichnis mit verfügbaren Wayland-Sitzungen</translation>
+        <translation>Verzeichnis mit verfügbaren Wayland-Sitzungen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ außer explizit aktiviert mit EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Pfad zur X-Server-Binärdatei</translation>
+        <translation>Pfad zur X-Server-Binärdatei</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumente, die an den X-Server-Aufruf übergeben werden</translation>
+        <translation>Argumente, die an den X-Server-Aufruf übergeben werden</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Verzeichnis mit verfügbaren X-Sitzungen</translation>
+        <translation>Verzeichnis mit verfügbaren X-Sitzungen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Pfad zu einem Skript, das beim Starten des Anzeigeservers ausgeführt werden soll</translation>
+        <translation>Pfad zu einem Skript, das beim Starten des Anzeigeservers ausgeführt werden soll</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Pfad zu einem Skript, das beim Stoppen des Anzeigeservers ausgeführt werden soll</translation>
+        <translation>Pfad zu einem Skript, das beim Stoppen des Anzeigeservers ausgeführt werden soll</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Pfad zur xauth-Binärdatei</translation>
+        <translation>Pfad zur xauth-Binärdatei</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Pfad zur Xephyr-Binärdatei</translation>
+        <translation>Pfad zur Xephyr-Binärdatei</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Pfad zur Xauthority-Datei</translation>
+        <translation>Pfad zur Xauthority-Datei</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Datei</translation>
+        <translation>Datei</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ außer explizit aktiviert mit EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM-Konfigurationseditor</translation>
+        <translation>SDDM-Konfigurationseditor</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_es.ts
+++ b/resources/translations/sddm-conf_es.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Inicio de sesión automático</translation>
+        <translation>Inicio de sesión automático</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Nombre de usuario para sesión de inicio automático</translation>
+        <translation>Nombre de usuario para sesión de inicio automático</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Decidir si sddm debería volver a iniciar sesión automáticamente al salir</translation>
+        <translation>Decidir si sddm debería volver a iniciar sesión automáticamente al salir</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Nombre del archivo de sesión para autoinicio de sesión (si en blanco, prueba última sesión)</translation>
+        <translation>Nombre del archivo de sesión para autoinicio de sesión (si en blanco, prueba última sesión)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">General</translation>
+        <translation>General</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Orden de reinicio</translation>
+        <translation>Orden de reinicio</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Si la propiedad está configurada como ninguno, el bloqueo numérico no será cambiado
+        <translation>Si la propiedad está configurada como ninguno, el bloqueo numérico no será cambiado
 NOTA: Actualmente es ignorado si el inicio automático de sesión está activado.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Estado inicial del bloqueo numérico. Puede ser activado, desactivado o ninguno.</translation>
+        <translation>Estado inicial del bloqueo numérico. Puede ser activado, desactivado o ninguno.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Módulo de método de entrada</translation>
+        <translation>Módulo de método de entrada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Orden para detener la máquina</translation>
+        <translation>Orden para detener la máquina</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Tema</translation>
+        <translation>Tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Ruta del directorio de temas</translation>
+        <translation>Ruta del directorio de temas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">sobre el cual se desactivarán los avatares
+        <translation>sobre el cual se desactivarán los avatares
 a menos que se activen explícitamente mediante EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Nombre del tema actual</translation>
+        <translation>Nombre del tema actual</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Tema de cursor usado en la pantalla de inicio de sesión</translation>
+        <translation>Tema de cursor usado en la pantalla de inicio de sesión</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Directorio global de avatares de usuario</translation>
+        <translation>Directorio global de avatares de usuario</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Número de usuarios para utilizar como umbral</translation>
+        <translation>Número de usuarios para utilizar como umbral</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Vista previa</translation>
+        <translation>Vista previa</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Activar visualización de avatares de usuario personalizados</translation>
+        <translation>Activar visualización de avatares de usuario personalizados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Los archivos deberían llamarse &lt;nombredeusuario&gt;.face.icon</translation>
+        <translation>Los archivos deberían llamarse &lt;nombredeusuario&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Usuarios</translation>
+        <translation>Usuarios</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">$PATH predeterminada para usuarios con sesión iniciada</translation>
+        <translation>$PATH predeterminada para usuarios con sesión iniciada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ a menos que se activen explícitamente mediante EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Lista separada por comas de usuarios que no deberían ser listados</translation>
+        <translation>Lista separada por comas de usuarios que no deberían ser listados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Mínimas identificaciones de usuario (uid) para usuarios mostrados</translation>
+        <translation>Mínimas identificaciones de usuario (uid) para usuarios mostrados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Máximas identificaciones de usuario (uid) para usuarios mostrados</translation>
+        <translation>Máximas identificaciones de usuario (uid) para usuarios mostrados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Recordar la sesión del último usuario que inició sesión existosamente</translation>
+        <translation>Recordar la sesión del último usuario que inició sesión existosamente</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Recordar al último usuario que inició sesión exitosamente</translation>
+        <translation>Recordar al último usuario que inició sesión exitosamente</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Activar escalado automático de alta resolución de Qt</translation>
+        <translation>Activar escalado automático de alta resolución de Qt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Ruta a la secuencia de órdenes que se ejecutará al iniciar la sesión del escritorio</translation>
+        <translation>Ruta a la secuencia de órdenes que se ejecutará al iniciar la sesión del escritorio</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Ruta al archivo de registros de la sesión de usuario</translation>
+        <translation>Ruta al archivo de registros de la sesión de usuario</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Directorio que contiene sesiones disponibles de Wayland</translation>
+        <translation>Directorio que contiene sesiones disponibles de Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ a menos que se activen explícitamente mediante EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Ruta al binario del servidor X</translation>
+        <translation>Ruta al binario del servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumentos pasados a la invocación del servidor X</translation>
+        <translation>Argumentos pasados a la invocación del servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Directorio que contiene sesiones disponibles de X</translation>
+        <translation>Directorio que contiene sesiones disponibles de X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Ruta a la secuencia de órdenes que se ejecutará al iniciar el servidor de pantallas</translation>
+        <translation>Ruta a la secuencia de órdenes que se ejecutará al iniciar el servidor de pantallas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Ruta a la secuencia de órdenes que se ejecutará al detener el servidor de pantallas</translation>
+        <translation>Ruta a la secuencia de órdenes que se ejecutará al detener el servidor de pantallas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Ruta al binario xauth</translation>
+        <translation>Ruta al binario xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Ruta al binario Xephyr</translation>
+        <translation>Ruta al binario Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Ruta al archivo Xauthority</translation>
+        <translation>Ruta al archivo Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Archivo</translation>
+        <translation>Archivo</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ a menos que se activen explícitamente mediante EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Editor de configuraciones de SDDM</translation>
+        <translation>Editor de configuraciones de SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_et.ts
+++ b/resources/translations/sddm-conf_et.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automaatne sisselogimine</translation>
+        <translation>Automaatne sisselogimine</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Kasutajanimi automaatsel sisselogimisel</translation>
+        <translation>Kasutajanimi automaatsel sisselogimisel</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Kas sddm peaks sesiooni lõpetamisel automaatselt uuesti sisse logima</translation>
+        <translation>Kas sddm peaks sesiooni lõpetamisel automaatselt uuesti sisse logima</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Sessioonifaili nimi automaatsel sisselogimisel (kui see väli on väärtustamata, siis proovi viimast sisselogimissessiooni)</translation>
+        <translation>Sessioonifaili nimi automaatsel sisselogimisel (kui see väli on väärtustamata, siis proovi viimast sisselogimissessiooni)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Üldseadistused</translation>
+        <translation>Üldseadistused</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Käsk arvuti taaskäivitamiseks</translation>
+        <translation>Käsk arvuti taaskäivitamiseks</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Kui väärtus on määramata, siis senine olek jääb muutmata
+        <translation>Kui väärtus on määramata, siis senine olek jääb muutmata
 Märkus: Kui automaatne sisselogimine on kasutusel, siis see seadistus jääb kasutamata.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Algne olek NumLock&apos;i jaoks. Võib olla sees, väljas või määramata.</translation>
+        <translation>Algne olek NumLock&apos;i jaoks. Võib olla sees, väljas või määramata.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Sisestusmeetodi moodul</translation>
+        <translation>Sisestusmeetodi moodul</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Käsk arvuti seiskamiseks</translation>
+        <translation>Käsk arvuti seiskamiseks</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Teema</translation>
+        <translation>Teema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Teemade kausta asukoht</translation>
+        <translation>Teemade kausta asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">mille puhul tunnuspildid jäävad kasutamata,
+        <translation>mille puhul tunnuspildid jäävad kasutamata,
 välja arvatud olukord, kui EnableAvatars nad üheselt kasutusele võtab</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Praeguse teema nimi</translation>
+        <translation>Praeguse teema nimi</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Kursoriteema sisselogimisvaates</translation>
+        <translation>Kursoriteema sisselogimisvaates</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Kasutajate tunnuspiltide üldine asukohakaust</translation>
+        <translation>Kasutajate tunnuspiltide üldine asukohakaust</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Kasutajate arvu lävi</translation>
+        <translation>Kasutajate arvu lävi</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Eelvaade</translation>
+        <translation>Eelvaade</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Luba kasutajate tunnuspiltide kuvamine</translation>
+        <translation>Luba kasutajate tunnuspiltide kuvamine</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Failide nimi peaks olema &lt;kasutajanimi&gt;.face.icon</translation>
+        <translation>Failide nimi peaks olema &lt;kasutajanimi&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Kasutajad</translation>
+        <translation>Kasutajad</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Vaikimisi $PATH sisseloginud kasutajatele</translation>
+        <translation>Vaikimisi $PATH sisseloginud kasutajatele</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ välja arvatud olukord, kui EnableAvatars nad üheselt kasutusele võtab</transl
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Komadega eraldatud loend kasutajatest, kes ei peaks olema sisselogimisvaates kuvatud</translation>
+        <translation>Komadega eraldatud loend kasutajatest, kes ei peaks olema sisselogimisvaates kuvatud</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Kuva kasutajaid, mille id on suurem kui</translation>
+        <translation>Kuva kasutajaid, mille id on suurem kui</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Kuva kasutajaid, mille id on väiksem kui</translation>
+        <translation>Kuva kasutajaid, mille id on väiksem kui</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Jäta viimase õnnestunult sisselogija sessioon meelde</translation>
+        <translation>Jäta viimase õnnestunult sisselogija sessioon meelde</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Jäta viimase õnnestunult sisselogija kasutajanimi meelde</translation>
+        <translation>Jäta viimase õnnestunult sisselogija kasutajanimi meelde</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Kasuta Qt automaatset skaleerimist kõrge DPI&apos;ga ekraani puhul</translation>
+        <translation>Kasuta Qt automaatset skaleerimist kõrge DPI&apos;ga ekraani puhul</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Töölauasessiooni sisselogimisel käivitatava skripti asukoht</translation>
+        <translation>Töölauasessiooni sisselogimisel käivitatava skripti asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Kasutajasessiooni logifaili asukoht</translation>
+        <translation>Kasutajasessiooni logifaili asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Kaust, kust otsitakse kasutatavaid Wayland&apos;i sessioone</translation>
+        <translation>Kaust, kust otsitakse kasutatavaid Wayland&apos;i sessioone</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ välja arvatud olukord, kui EnableAvatars nad üheselt kasutusele võtab</transl
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">X serveri rakendusefaili asukoht</translation>
+        <translation>X serveri rakendusefaili asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">X serveri käivitamisel lisatavad argumendid</translation>
+        <translation>X serveri käivitamisel lisatavad argumendid</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Kaust, kust otsitakse kasutatavaid X serveri sessioone</translation>
+        <translation>Kaust, kust otsitakse kasutatavaid X serveri sessioone</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Graafilise liidese töö alustamisel käivitatava skripti asukoht</translation>
+        <translation>Graafilise liidese töö alustamisel käivitatava skripti asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Graafilise liidese töö lõpetamisel käivitatava skripti asukoht</translation>
+        <translation>Graafilise liidese töö lõpetamisel käivitatava skripti asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Xauth rakendusefaili asukoht</translation>
+        <translation>Xauth rakendusefaili asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Xephyr rakendusefaili asukoht</translation>
+        <translation>Xephyr rakendusefaili asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Xauthority faili asukoht</translation>
+        <translation>Xauthority faili asukoht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Fail</translation>
+        <translation>Fail</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ välja arvatud olukord, kui EnableAvatars nad üheselt kasutusele võtab</transl
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM seadistuste haldur</translation>
+        <translation>SDDM seadistuste haldur</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_fr.ts
+++ b/resources/translations/sddm-conf_fr.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Connexion automatique</translation>
+        <translation>Connexion automatique</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Nom d&apos;utilisateur pour la session connectée automatiquement</translation>
+        <translation>Nom d&apos;utilisateur pour la session connectée automatiquement</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Indiquer si sddm doit se reconnecter automatiquement aux sessions à leur sortie</translation>
+        <translation>Indiquer si sddm doit se reconnecter automatiquement aux sessions à leur sortie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Nom de la session pour la connexion automatique (si vide, ce sera la dernière session connectée)</translation>
+        <translation>Nom de la session pour la connexion automatique (si vide, ce sera la dernière session connectée)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Générale</translation>
+        <translation>Générale</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Commande de redémarrage</translation>
+        <translation>Commande de redémarrage</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Si la propriété est définie sur &quot;none&quot;, le verrouillage numérique ne sera pas modifié
+        <translation>Si la propriété est définie sur &quot;none&quot;, le verrouillage numérique ne sera pas modifié
 REMARQUE : Actuellement ignoré si la connexion automatique est activée.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">État initial du verrouillage numérique. Peut être &quot;on&quot;, &quot;off&quot; ou &quot;none&quot;.</translation>
+        <translation>État initial du verrouillage numérique. Peut être &quot;on&quot;, &quot;off&quot; ou &quot;none&quot;.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Module de méthode d&apos;entrée</translation>
+        <translation>Module de méthode d&apos;entrée</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Commande d&apos;arrêt</translation>
+        <translation>Commande d&apos;arrêt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Thème</translation>
+        <translation>Thème</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Chemin du répertoire du thème</translation>
+        <translation>Chemin du répertoire du thème</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">seuil au-dessus duquel les avatars sont désactivés
+        <translation>seuil au-dessus duquel les avatars sont désactivés
 sauf si explicitement activé avec EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Nom du thème actuel</translation>
+        <translation>Nom du thème actuel</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Thème du curseur utilisé dans l&apos;écran d&apos;accueil</translation>
+        <translation>Thème du curseur utilisé dans l&apos;écran d&apos;accueil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Répertoire global des avatars des utilisateurs</translation>
+        <translation>Répertoire global des avatars des utilisateurs</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Nombre d&apos;utilisateurs à utiliser comme seuil</translation>
+        <translation>Nombre d&apos;utilisateurs à utiliser comme seuil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Aperçu</translation>
+        <translation>Aperçu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Activer l&apos;affichage des avatars d&apos;utilisateurs personnalisés</translation>
+        <translation>Activer l&apos;affichage des avatars d&apos;utilisateurs personnalisés</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Ce dossier doit être nommé&lt;username&gt;.face.icon</translation>
+        <translation>Ce dossier doit être nommé&lt;username&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Utilisateurs</translation>
+        <translation>Utilisateurs</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">$CHEMIN par défaut pour les utilisateurs connectés</translation>
+        <translation>$CHEMIN par défaut pour les utilisateurs connectés</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ sauf si explicitement activé avec EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Liste des utilisateurs séparés par des virgules qui ne doivent pas être répertoriés</translation>
+        <translation>Liste des utilisateurs séparés par des virgules qui ne doivent pas être répertoriés</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">ID utilisateur minimum pour les utilisateurs affichés</translation>
+        <translation>ID utilisateur minimum pour les utilisateurs affichés</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">ID utilisateur maximum pour les utilisateurs affichés</translation>
+        <translation>ID utilisateur maximum pour les utilisateurs affichés</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Se souvenir de la session du dernier utilisateur connecté avec succès</translation>
+        <translation>Se souvenir de la session du dernier utilisateur connecté avec succès</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Se souvenir du dernier utilisateur connecté avec succès</translation>
+        <translation>Se souvenir du dernier utilisateur connecté avec succès</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Activer la mise à l&apos;échelle automatique à haute résolution de Qt</translation>
+        <translation>Activer la mise à l&apos;échelle automatique à haute résolution de Qt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Chemin vers un script à exécuter lors du démarrage de la session de bureau</translation>
+        <translation>Chemin vers un script à exécuter lors du démarrage de la session de bureau</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Chemin d&apos;accès au fichier journal de session utilisateur</translation>
+        <translation>Chemin d&apos;accès au fichier journal de session utilisateur</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Répertoire contenant les sessions Wayland disponibles</translation>
+        <translation>Répertoire contenant les sessions Wayland disponibles</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ sauf si explicitement activé avec EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Chemin vers le binaire du serveur X</translation>
+        <translation>Chemin vers le binaire du serveur X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Arguments passés à l&apos;appel du serveur X</translation>
+        <translation>Arguments passés à l&apos;appel du serveur X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Répertoire contenant les sessions X disponibles</translation>
+        <translation>Répertoire contenant les sessions X disponibles</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Chemin vers un script à exécuter lors du démarrage du serveur d&apos;affichage</translation>
+        <translation>Chemin vers un script à exécuter lors du démarrage du serveur d&apos;affichage</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Chemin vers un script à exécuter lors de l&apos;arrêt du serveur d&apos;affichage</translation>
+        <translation>Chemin vers un script à exécuter lors de l&apos;arrêt du serveur d&apos;affichage</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Chemin vers le binaire xauth</translation>
+        <translation>Chemin vers le binaire xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Chemin vers le binaire Xephyr</translation>
+        <translation>Chemin vers le binaire Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Chemin vers le fichier Xauthority</translation>
+        <translation>Chemin vers le fichier Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Fichier</translation>
+        <translation>Fichier</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ sauf si explicitement activé avec EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Éditeur de configuration de SDDM</translation>
+        <translation>Éditeur de configuration de SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_he.ts
+++ b/resources/translations/sddm-conf_he.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">כניסה אוטומטית</translation>
+        <translation>כניסה אוטומטית</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">שם משתמש לכניסה אוטומטית להפעלה</translation>
+        <translation>שם משתמש לכניסה אוטומטית להפעלה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">האם sddm אמור להכניס אוטומטית משתמשים כשהם יוצאים</translation>
+        <translation>האם sddm אמור להכניס אוטומטית משתמשים כשהם יוצאים</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">שם קובץ ההפעלה לכניסה אוטומטית להפעלה (אם ריק לנסות את הכניסה האחרונה)</translation>
+        <translation>שם קובץ ההפעלה לכניסה אוטומטית להפעלה (אם ריק לנסות את הכניסה האחרונה)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">כללי</translation>
+        <translation>כללי</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">פקודת הפעלה מחדש</translation>
+        <translation>פקודת הפעלה מחדש</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">אם המאפיין הוגדר ל־none (נטול החלטה), מצב ה־numlock לא ישתנה
+        <translation>אם המאפיין הוגדר ל־none (נטול החלטה), מצב ה־numlock לא ישתנה
 לתשומת לבך: לא תקף אם מופעלת כניסה אוטומטית.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">מצב ה־NumLock ההתחלתי. יכול להיות on,‏ off או none (פעיל, כבוי או נטול החלטה).</translation>
+        <translation>מצב ה־NumLock ההתחלתי. יכול להיות on,‏ off או none (פעיל, כבוי או נטול החלטה).</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">מודול שיטת קלט</translation>
+        <translation>מודול שיטת קלט</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">פקודת השבתה</translation>
+        <translation>פקודת השבתה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">ערכת נושא</translation>
+        <translation>ערכת נושא</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">נתיב תיקיית ערכות הנושא</translation>
+        <translation>נתיב תיקיית ערכות הנושא</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">מעבר לכך התמונות הייצוגיות יושבתו
+        <translation>מעבר לכך התמונות הייצוגיות יושבתו
 אלא אם כן הופעלו מפורשות עם EnableAvatars (הפעלת תמונות ייצוגיות)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">שם ערכת הנושא הנוכחית</translation>
+        <translation>שם ערכת הנושא הנוכחית</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">ערכת המצביעים בה יעשה שימוש במקבל הפנים</translation>
+        <translation>ערכת המצביעים בה יעשה שימוש במקבל הפנים</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">תיקייה גלובלית של תמונות משתמש ייצוגיות</translation>
+        <translation>תיקייה גלובלית של תמונות משתמש ייצוגיות</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">מספר המשתמשים לשימוש בתור סף</translation>
+        <translation>מספר המשתמשים לשימוש בתור סף</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">תצוגה מקדימה</translation>
+        <translation>תצוגה מקדימה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">הפעלת הצגת תמונות ייצוגיות אישיות</translation>
+        <translation>הפעלת הצגת תמונות ייצוגיות אישיות</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">יש לקרוא לקבצים ‎ &lt;username&gt;.face.icon(להחליף בשם המשתמש)</translation>
+        <translation>יש לקרוא לקבצים ‎ &lt;username&gt;.face.icon(להחליף בשם המשתמש)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">משתמשים</translation>
+        <translation>משתמשים</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">‎$PATH בררת מחדל למשתמשים שנכנסו למערכת</translation>
+        <translation>‎$PATH בררת מחדל למשתמשים שנכנסו למערכת</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">רשימה מופרדת בפסיקים של משתמשים שלא אמורים להופיע</translation>
+        <translation>רשימה מופרדת בפסיקים של משתמשים שלא אמורים להופיע</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">מזהה המשתמש המזערי למשתמשים המוצגים</translation>
+        <translation>מזהה המשתמש המזערי למשתמשים המוצגים</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">מזהה המשתמש המרבי למשתמשים המוצגים</translation>
+        <translation>מזהה המשתמש המרבי למשתמשים המוצגים</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">לזכור את ההפעלה של המשתמש האחרון שהצליח להיכנס</translation>
+        <translation>לזכור את ההפעלה של המשתמש האחרון שהצליח להיכנס</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">לזכור את המשתמש האחרון שנכנס בהצלחה</translation>
+        <translation>לזכור את המשתמש האחרון שנכנס בהצלחה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">להפעיל את ההתאמה האוטומטית של Qt לרזולוציה גבוהה (Hi-DPI)</translation>
+        <translation>להפעיל את ההתאמה האוטומטית של Qt לרזולוציה גבוהה (Hi-DPI)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">נתיב לסקריפט שיופעל עם התחלת פעילות שולחן העבודה</translation>
+        <translation>נתיב לסקריפט שיופעל עם התחלת פעילות שולחן העבודה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">נתיב לקובץ יומן הפעלת המשתמש</translation>
+        <translation>נתיב לקובץ יומן הפעלת המשתמש</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">תיקייה שמכילה הפעלות Wayland זמינות</translation>
+        <translation>תיקייה שמכילה הפעלות Wayland זמינות</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">נתיב לבינרי של שרת ה־X</translation>
+        <translation>נתיב לבינרי של שרת ה־X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">ארגומנטים שהועברו להפעלת שרת ה־X</translation>
+        <translation>ארגומנטים שהועברו להפעלת שרת ה־X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">תיקייה שמכילה הפעלות X זמינות</translation>
+        <translation>תיקייה שמכילה הפעלות X זמינות</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">נתיב לסקריפט שירוץ עם הפעלת שרת התצוגה</translation>
+        <translation>נתיב לסקריפט שירוץ עם הפעלת שרת התצוגה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">נתיב לסקריפט שירוץ עם עצירת שרת התצוגה</translation>
+        <translation>נתיב לסקריפט שירוץ עם עצירת שרת התצוגה</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">נתיב לבינרי xauth</translation>
+        <translation>נתיב לבינרי xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">נתיב לבינרי של Xephyr</translation>
+        <translation>נתיב לבינרי של Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">נתיב לקובץ ה־Xauthority</translation>
+        <translation>נתיב לקובץ ה־Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">קובץ</translation>
+        <translation>קובץ</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">עורך הגדרת SDDM</translation>
+        <translation>עורך הגדרת SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_hr.ts
+++ b/resources/translations/sddm-conf_hr.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatska prijava</translation>
+        <translation>Automatska prijava</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Korisničko ime za sesiju automatske prijave</translation>
+        <translation>Korisničko ime za sesiju automatske prijave</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Treba li se sddm automatski ponovo prijaviti u sesije, kad se prekinu</translation>
+        <translation>Treba li se sddm automatski ponovo prijaviti u sesije, kad se prekinu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Ime datoteke sesije za sesiju automatske prijave (ako je prazno, pokušaj zadnju prijavu)</translation>
+        <translation>Ime datoteke sesije za sesiju automatske prijave (ako je prazno, pokušaj zadnju prijavu)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Opće</translation>
+        <translation>Opće</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Ponovo pokreni naredbu</translation>
+        <translation>Ponovo pokreni naredbu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Ako je za svojstvo postavljeno na ništa, numeričke tipke se neće mijenjati
+        <translation>Ako je za svojstvo postavljeno na ništa, numeričke tipke se neće mijenjati
 NAPOMENA: Trenutačno se zanemaruje, ako je aktivirana automatska prijava.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Izvorno stanje numeričkih tipki. Može biti uključeno, isključeno ili ništa.</translation>
+        <translation>Izvorno stanje numeričkih tipki. Može biti uključeno, isključeno ili ništa.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Modul metode unosa</translation>
+        <translation>Modul metode unosa</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Zaustavi naradbu</translation>
+        <translation>Zaustavi naradbu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Tema</translation>
+        <translation>Tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Staza mape tema</translation>
+        <translation>Staza mape tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">iznad kojih su avatari aktivirani
+        <translation>iznad kojih su avatari aktivirani
 osim ako nije izričito aktivirano s EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Ime trenutačne teme</translation>
+        <translation>Ime trenutačne teme</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Tema pokazivača korištena u pozdravnom prozoru</translation>
+        <translation>Tema pokazivača korištena u pozdravnom prozoru</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Globalna mapa za avatare korisnika</translation>
+        <translation>Globalna mapa za avatare korisnika</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Broj korisnika korišten kao prag</translation>
+        <translation>Broj korisnika korišten kao prag</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Pregled</translation>
+        <translation>Pregled</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Aktiviraj prikaz prilagođenih avatara korisnika</translation>
+        <translation>Aktiviraj prikaz prilagođenih avatara korisnika</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Ova se datoteka mora zvati &lt;username&gt;.face.icon</translation>
+        <translation>Ova se datoteka mora zvati &lt;username&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Korisnici</translation>
+        <translation>Korisnici</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Standardna staza $PATH za prijavljene korisnike</translation>
+        <translation>Standardna staza $PATH za prijavljene korisnike</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ osim ako nije izričito aktivirano s EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Zarezom odijeljeni popis korisnika koji se ne trebaju navesti</translation>
+        <translation>Zarezom odijeljeni popis korisnika koji se ne trebaju navesti</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Minimalni id korisnika za prikazane korisnike</translation>
+        <translation>Minimalni id korisnika za prikazane korisnike</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Maksimalni id korisnika za prikazane korisnike</translation>
+        <translation>Maksimalni id korisnika za prikazane korisnike</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Zapamti sesiju zadnjeg uspješno prijavljenog korisnika</translation>
+        <translation>Zapamti sesiju zadnjeg uspješno prijavljenog korisnika</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Zapamti zadnjeg uspješno prijavljenog korisnika</translation>
+        <translation>Zapamti zadnjeg uspješno prijavljenog korisnika</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Aktiviraj Qt-ovo automatsko skaliranje DPI-a</translation>
+        <translation>Aktiviraj Qt-ovo automatsko skaliranje DPI-a</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Staza skripta za izvršavanje, prilikom pokretanja sesije radne površine</translation>
+        <translation>Staza skripta za izvršavanje, prilikom pokretanja sesije radne površine</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Staza do datoteke korisničkog zapisa sesije</translation>
+        <translation>Staza do datoteke korisničkog zapisa sesije</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Direktorij s dostupnom Wayland sesijom</translation>
+        <translation>Direktorij s dostupnom Wayland sesijom</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ osim ako nije izričito aktivirano s EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Staza do binarnih podataka X poslužitelja</translation>
+        <translation>Staza do binarnih podataka X poslužitelja</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Pozivu X poslužitelja proslijeđeni argumenti</translation>
+        <translation>Pozivu X poslužitelja proslijeđeni argumenti</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Mapa koja sadrži dostupne X sesije</translation>
+        <translation>Mapa koja sadrži dostupne X sesije</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Staza do skripta koji se treba izvršiti prilikom pokretanja poslužitelja ekrana</translation>
+        <translation>Staza do skripta koji se treba izvršiti prilikom pokretanja poslužitelja ekrana</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Staza do skripta koji se treba izvršiti prilikom zaustavljanja poslužitelja ekrana</translation>
+        <translation>Staza do skripta koji se treba izvršiti prilikom zaustavljanja poslužitelja ekrana</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Staza za xauth binarne podatke</translation>
+        <translation>Staza za xauth binarne podatke</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Staza za Xephyr binarne podatke</translation>
+        <translation>Staza za Xephyr binarne podatke</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Staza Xauthority-datoteke</translation>
+        <translation>Staza Xauthority-datoteke</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Datoteka</translation>
+        <translation>Datoteka</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ osim ako nije izričito aktivirano s EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Uređivač SDDM konfiguracije</translation>
+        <translation>Uređivač SDDM konfiguracije</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_hu.ts
+++ b/resources/translations/sddm-conf_hu.ts
@@ -6,17 +6,17 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatikus bejelentkezés</translation>
+        <translation>Automatikus bejelentkezés</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Felhasználónév az automatikus munkamenethez</translation>
+        <translation>Felhasználónév az automatikus munkamenethez</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Visszajelentkezzen-e az sddm automatikusan a munkamenetekbe, amikor kilépnek</translation>
+        <translation>Visszajelentkezzen-e az sddm automatikusan a munkamenetekbe, amikor kilépnek</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
@@ -26,12 +26,12 @@
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Általános</translation>
+        <translation>Általános</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Újraindítás parancs</translation>
+        <translation>Újraindítás parancs</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
@@ -57,7 +57,7 @@ NOTE: Currently ignored if autologin is enabled.</source>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Téma</translation>
+        <translation>Téma</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
@@ -73,7 +73,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Jelenlegi témanév</translation>
+        <translation>Jelenlegi témanév</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
@@ -154,7 +154,7 @@ unless explicitly enabled with EnableAvatars</source>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">A Qt automatikus magas-DPI felbontásának engedélyezése</translation>
+        <translation>A Qt automatikus magas-DPI felbontásának engedélyezése</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>

--- a/resources/translations/sddm-conf_ja.ts
+++ b/resources/translations/sddm-conf_ja.ts
@@ -6,115 +6,115 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">自動ログイン</translation>
+        <translation>自動ログイン</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">自動ログインセッションのためのユーザー名</translation>
+        <translation>自動ログインセッションのためのユーザー名</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">セッションが終了した時 SDDM が自動的にセッションにログインし直すかどうか</translation>
+        <translation>セッションが終了した時 SDDM が自動的にセッションにログインし直すかどうか</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">自動ログインセッションのためのセッションファイル名(空の場合は最後にログインしたファイルを試します)</translation>
+        <translation>自動ログインセッションのためのセッションファイル名(空の場合は最後にログインしたファイルを試します)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">全般</translation>
+        <translation>全般</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">再起動のコマンド</translation>
+        <translation>再起動のコマンド</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">プロパティが none に設定されている場合、NumLock は変更されません。
+        <translation>プロパティが none に設定されている場合、NumLock は変更されません。
 注: 現在、自動ログインが有効になっている場合は無視されます。</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">NumLock の初期状態。on, off, none のいずれかです。</translation>
+        <translation>NumLock の初期状態。on, off, none のいずれかです。</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">入力メソッドのモジュール</translation>
+        <translation>入力メソッドのモジュール</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">中止コマンド</translation>
+        <translation>中止コマンド</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">テーマ</translation>
+        <translation>テーマ</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">テーマのディレクトリパス</translation>
+        <translation>テーマのディレクトリパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">それを超えると、EnableAvatars で明示的に有効にされていない限りアバターは無効になります</translation>
+        <translation>それを超えると、EnableAvatars で明示的に有効にされていない限りアバターは無効になります</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">現在のテーマ名</translation>
+        <translation>現在のテーマ名</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">グリーターで使用するカーソルテーマ</translation>
+        <translation>グリーターで使用するカーソルテーマ</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">ユーザーアバターのグローバルなディレクトリ</translation>
+        <translation>ユーザーアバターのグローバルなディレクトリ</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">しきい値として使用するユーザー数</translation>
+        <translation>しきい値として使用するユーザー数</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">プレビュー</translation>
+        <translation>プレビュー</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">ユーザーが設定するアバターの表示を有効にする</translation>
+        <translation>ユーザーが設定するアバターの表示を有効にする</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">ファイルは &lt;username&gt;.face.icon と名前を付けます</translation>
+        <translation>ファイルは &lt;username&gt;.face.icon と名前を付けます</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">ユーザー</translation>
+        <translation>ユーザー</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">ログインするユーザーの $PATH の既定値</translation>
+        <translation>ログインするユーザーの $PATH の既定値</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -124,60 +124,60 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">リストすべきでないユーザーのコンマ区切りのリスト</translation>
+        <translation>リストすべきでないユーザーのコンマ区切りのリスト</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">表示するユーザーの最小 UID</translation>
+        <translation>表示するユーザーの最小 UID</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">表示するユーザーの最大 UID</translation>
+        <translation>表示するユーザーの最大 UID</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">最後に正常にログインしたユーザーのセッションを記憶する</translation>
+        <translation>最後に正常にログインしたユーザーのセッションを記憶する</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">最後に正常にログインしたユーザーを記憶する</translation>
+        <translation>最後に正常にログインしたユーザーを記憶する</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Qt の自動 HiDPI スケールを有効にする</translation>
+        <translation>Qt の自動 HiDPI スケールを有効にする</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">デスクトップセッションの起動時に実行するスクリプトへのパス</translation>
+        <translation>デスクトップセッションの起動時に実行するスクリプトへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">ユーザーセッションのログファイルへのパス</translation>
+        <translation>ユーザーセッションのログファイルへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">使用可能な Wayland セッションを含むディレクトリ</translation>
+        <translation>使用可能な Wayland セッションを含むディレクトリ</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -187,47 +187,47 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">X サーバーのバイナリへのパス</translation>
+        <translation>X サーバーのバイナリへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">X サーバー呼び出しに渡される引数</translation>
+        <translation>X サーバー呼び出しに渡される引数</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">使用可能な X セッションを含むディレクトリ</translation>
+        <translation>使用可能な X セッションを含むディレクトリ</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">ディスプレイサーバーの起動時に実行するスクリプトへのパス</translation>
+        <translation>ディスプレイサーバーの起動時に実行するスクリプトへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">ディスプレイサーバーの停止時に実行するスクリプトへのパス</translation>
+        <translation>ディスプレイサーバーの停止時に実行するスクリプトへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">xauth バイナリへのパス</translation>
+        <translation>xauth バイナリへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Xephyr バイナリへのパス</translation>
+        <translation>Xephyr バイナリへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Xauthority ファイルへのパス</translation>
+        <translation>Xauthority ファイルへのパス</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">ファイル</translation>
+        <translation>ファイル</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -237,7 +237,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM 設定エディター</translation>
+        <translation>SDDM 設定エディター</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_ko.ts
+++ b/resources/translations/sddm-conf_ko.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">자동로그인</translation>
+        <translation>자동로그인</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">자동 로그인 세션의 사용자 이름</translation>
+        <translation>자동 로그인 세션의 사용자 이름</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">세션이 종료될 때 sddm이 자동으로 세션에 다시 로그인해야 하는지 여부</translation>
+        <translation>세션이 종료될 때 sddm이 자동으로 세션에 다시 로그인해야 하는지 여부</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">자동 로그인 세션의 세션 파일 이름(비어 있는 경우 마지막 로그인 시도)</translation>
+        <translation>자동 로그인 세션의 세션 파일 이름(비어 있는 경우 마지막 로그인 시도)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">일반</translation>
+        <translation>일반</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">재부팅 명령</translation>
+        <translation>재부팅 명령</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">속성을 없음으로 설정하면 numlock이 변경되지 않습니다.
+        <translation>속성을 없음으로 설정하면 numlock이 변경되지 않습니다.
 참고: 자동 로그인이 활성화된 경우 현재 무시됩니다.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">초기 NumLock 상태입니다. 켜짐, 꺼짐 또는 없음이 될 수 있습니다.</translation>
+        <translation>초기 NumLock 상태입니다. 켜짐, 꺼짐 또는 없음이 될 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">입력기 모듈</translation>
+        <translation>입력기 모듈</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">중지 명령</translation>
+        <translation>중지 명령</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">테마</translation>
+        <translation>테마</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">테마 디렉터리 경로</translation>
+        <translation>테마 디렉터리 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">아바타활성화를 사용하여 명시적으로 활성화되지
+        <translation>아바타활성화를 사용하여 명시적으로 활성화되지
 않는 한 위의 아바타는 비활성화됩니다</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">현재 테마 이름</translation>
+        <translation>현재 테마 이름</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">인사말에 사용된 커서 테마</translation>
+        <translation>인사말에 사용된 커서 테마</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">사용자 아바타의 전역 디렉터리</translation>
+        <translation>사용자 아바타의 전역 디렉터리</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">임계값으로 사용할 사용자 수</translation>
+        <translation>임계값으로 사용할 사용자 수</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">미리보기</translation>
+        <translation>미리보기</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">사용자 지정 사용자 아바타 화면표시 활성화</translation>
+        <translation>사용자 지정 사용자 아바타 화면표시 활성화</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">파일 이름은 &lt;사용자이름&gt;.face.icon이어야 합니다</translation>
+        <translation>파일 이름은 &lt;사용자이름&gt;.face.icon이어야 합니다</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">사용자</translation>
+        <translation>사용자</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">로그인한 사용자의 기본 $PATH</translation>
+        <translation>로그인한 사용자의 기본 $PATH</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">나열하면 안 되는 쉼표로 구분된 사용자 목록</translation>
+        <translation>나열하면 안 되는 쉼표로 구분된 사용자 목록</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">화면표시된 사용자의 최소 사용자 ID</translation>
+        <translation>화면표시된 사용자의 최소 사용자 ID</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">화면표시된 사용자의 최대 사용자 ID</translation>
+        <translation>화면표시된 사용자의 최대 사용자 ID</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">마지막으로 성공적으로 로그인한 사용자의 세션 기억</translation>
+        <translation>마지막으로 성공적으로 로그인한 사용자의 세션 기억</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">마지막으로 성공적으로 로그인한 사용자 기억</translation>
+        <translation>마지막으로 성공적으로 로그인한 사용자 기억</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Qt의 높은 DPI 자동 스케일링 활성화</translation>
+        <translation>Qt의 높은 DPI 자동 스케일링 활성화</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">바탕화면 세션을 시작할 때 실행할 스크립트 경로</translation>
+        <translation>바탕화면 세션을 시작할 때 실행할 스크립트 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">사용자 세션 로그 파일의 경로</translation>
+        <translation>사용자 세션 로그 파일의 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">사용 가능한 Wayland 세션이 포함된 디렉터리</translation>
+        <translation>사용 가능한 Wayland 세션이 포함된 디렉터리</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">X 서버 바이너리 경로</translation>
+        <translation>X 서버 바이너리 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">X 서버 호출에 전달된 인수</translation>
+        <translation>X 서버 호출에 전달된 인수</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">사용 가능한 X 세션이 포함된 디렉터리</translation>
+        <translation>사용 가능한 X 세션이 포함된 디렉터리</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">디스플레이 서버를 시작할 때 실행할 스크립트 경로</translation>
+        <translation>디스플레이 서버를 시작할 때 실행할 스크립트 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">디스플레이 서버를 중지할 때 실행할 스크립트 경로</translation>
+        <translation>디스플레이 서버를 중지할 때 실행할 스크립트 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">xauth 바이너리 경로</translation>
+        <translation>xauth 바이너리 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Xephyr 바이너리 경로</translation>
+        <translation>Xephyr 바이너리 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Xauthority 파일의 경로</translation>
+        <translation>Xauthority 파일의 경로</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">파일</translation>
+        <translation>파일</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM 구성 편집기</translation>
+        <translation>SDDM 구성 편집기</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_lt.ts
+++ b/resources/translations/sddm-conf_lt.ts
@@ -6,117 +6,117 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatinis prisijungimas</translation>
+        <translation>Automatinis prisijungimas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Naudotojo vardas, skirtas automatinio prisijungimo seansui</translation>
+        <translation>Naudotojo vardas, skirtas automatinio prisijungimo seansui</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Ar sddm turėtų automatiškai prisijungti atgal į seansus, kai iš jų išeinama</translation>
+        <translation>Ar sddm turėtų automatiškai prisijungti atgal į seansus, kai iš jų išeinama</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Seanso failo, skirto automatinio prisijungimo seansui (jei tuščia, bandyti paskutinį, kuriuo pavyko prisijungti), pavadinimas</translation>
+        <translation>Seanso failo, skirto automatinio prisijungimo seansui (jei tuščia, bandyti paskutinį, kuriuo pavyko prisijungti), pavadinimas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Bendra</translation>
+        <translation>Bendra</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Paleidimo iš naujo komanda</translation>
+        <translation>Paleidimo iš naujo komanda</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Jei savybė nustatyta į jokią (none),
+        <translation>Jei savybė nustatyta į jokią (none),
 klaviatūros skaitmenų būsena nebus keičiama
 PASTABA: Šiuo metu nepaisoma, jei įjungtas automatinis prisijungimas.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Pradinė klaviatūros skaitmenų (NumLock) būsena. Gali būti įjungta (on), išjungta (off) arba jokia (none).</translation>
+        <translation>Pradinė klaviatūros skaitmenų (NumLock) būsena. Gali būti įjungta (on), išjungta (off) arba jokia (none).</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Įvesties metodo modulis</translation>
+        <translation>Įvesties metodo modulis</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Išjungimo komanda</translation>
+        <translation>Išjungimo komanda</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Apipavidalinimas</translation>
+        <translation>Apipavidalinimas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Apipavidalinimo katalogo kelias</translation>
+        <translation>Apipavidalinimo katalogo kelias</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">virš kurių avatarai yra išjungti,
+        <translation>virš kurių avatarai yra išjungti,
 nebent aiškiai įjungta naudojant EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Dabartinio apipavidalinimo pavadinimas</translation>
+        <translation>Dabartinio apipavidalinimo pavadinimas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Žymeklio apipavidalinimas, naudojamas pasisveikinime</translation>
+        <translation>Žymeklio apipavidalinimas, naudojamas pasisveikinime</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Visuotinis naudotojų avatarų katalogas</translation>
+        <translation>Visuotinis naudotojų avatarų katalogas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Naudotojų skaičius, kurį naudoti kaip slenkstį</translation>
+        <translation>Naudotojų skaičius, kurį naudoti kaip slenkstį</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Peržiūra</translation>
+        <translation>Peržiūra</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Įjungti tinkintų naudotojų avatarų rodymą</translation>
+        <translation>Įjungti tinkintų naudotojų avatarų rodymą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Failų pavadinimai turėtų būti &lt;naudotojo_vardas&gt;.face.icon</translation>
+        <translation>Failų pavadinimai turėtų būti &lt;naudotojo_vardas&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Naudotojai</translation>
+        <translation>Naudotojai</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Numatytasis $PATH prisijungusiems naudotojams</translation>
+        <translation>Numatytasis $PATH prisijungusiems naudotojams</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -126,60 +126,60 @@ nebent aiškiai įjungta naudojant EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Kableliais atskirtų naudotojų, kurie neturėtų būti išvardyti, sąrašas</translation>
+        <translation>Kableliais atskirtų naudotojų, kurie neturėtų būti išvardyti, sąrašas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Mažiausias naudotojo id rodomiems naudotojams</translation>
+        <translation>Mažiausias naudotojo id rodomiems naudotojams</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Didžiausias naudotojo id rodomiems naudotojams</translation>
+        <translation>Didžiausias naudotojo id rodomiems naudotojams</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Prisiminti paskutinio sėkmingai prisijungusio naudotojo seansą</translation>
+        <translation>Prisiminti paskutinio sėkmingai prisijungusio naudotojo seansą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Prisiminti paskutinį sėkmingai prisijungusį naudotoją</translation>
+        <translation>Prisiminti paskutinį sėkmingai prisijungusį naudotoją</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Įjungti Qt automatinį didelės DPI reikšmės mastelio keitimą</translation>
+        <translation>Įjungti Qt automatinį didelės DPI reikšmės mastelio keitimą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Kelias į scenarijų, kurį vykdyti paleidžiant darbalaukio seansą</translation>
+        <translation>Kelias į scenarijų, kurį vykdyti paleidžiant darbalaukio seansą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Kelias į naudotojo seanso žurnalo failą</translation>
+        <translation>Kelias į naudotojo seanso žurnalo failą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Katalogas su prieinamais Wayland seansais</translation>
+        <translation>Katalogas su prieinamais Wayland seansais</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -189,47 +189,47 @@ nebent aiškiai įjungta naudojant EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Kelias į X serverio dvejetainę</translation>
+        <translation>Kelias į X serverio dvejetainę</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumentai, perduodami į X serverio iškvietą</translation>
+        <translation>Argumentai, perduodami į X serverio iškvietą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Katalogas su prieinamais X seansais</translation>
+        <translation>Katalogas su prieinamais X seansais</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Kelias į scenarijų, kurį vykdyti, kai paleidžiamas atvaizdavimo serveris</translation>
+        <translation>Kelias į scenarijų, kurį vykdyti, kai paleidžiamas atvaizdavimo serveris</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Kelias į scenarijų, kurį vykdyti, kai stabdomas atvaizdavimo serveris</translation>
+        <translation>Kelias į scenarijų, kurį vykdyti, kai stabdomas atvaizdavimo serveris</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Kelias į xauth dvejetainę</translation>
+        <translation>Kelias į xauth dvejetainę</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Kelias į Xephyr dvejetainę</translation>
+        <translation>Kelias į Xephyr dvejetainę</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Kelias į Xauthority failą</translation>
+        <translation>Kelias į Xauthority failą</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Failas</translation>
+        <translation>Failas</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -239,7 +239,7 @@ nebent aiškiai įjungta naudojant EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM konfigūracijos redaktorius</translation>
+        <translation>SDDM konfigūracijos redaktorius</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_nb_NO.ts
+++ b/resources/translations/sddm-conf_nb_NO.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatisk innlogging</translation>
+        <translation>Automatisk innlogging</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Brukernavn for automatisk innlogget økt</translation>
+        <translation>Brukernavn for automatisk innlogget økt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Hvorvidt SDDM skal logge inn i økter igjen automatisk når de avsluttes</translation>
+        <translation>Hvorvidt SDDM skal logge inn i økter igjen automatisk når de avsluttes</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Navnet på øktfilen for autoinnloggingsøkt (hvis tom prøv sist innlogget)</translation>
+        <translation>Navnet på øktfilen for autoinnloggingsøkt (hvis tom prøv sist innlogget)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Generelt</translation>
+        <translation>Generelt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Omstartskommando</translation>
+        <translation>Omstartskommando</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Hvis egenskapen settes til ingen, vil ikke numlock endres.
+        <translation>Hvis egenskapen settes til ingen, vil ikke numlock endres.
 Merk: Ses bort fra hvis automatisk innlogging er påskrudd.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Oppstartstilstand for NumLock. Kan være på, av, eller ingen.</translation>
+        <translation>Oppstartstilstand for NumLock. Kan være på, av, eller ingen.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Inndatametode-modul</translation>
+        <translation>Inndatametode-modul</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Hold kommando</translation>
+        <translation>Hold kommando</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Drakt</translation>
+        <translation>Drakt</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Draktmappesti</translation>
+        <translation>Draktmappesti</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">over de avatarene som er avskrudd,
+        <translation>over de avatarene som er avskrudd,
 med mindre de skrus på spesifikt med EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Nåværende draktnavn</translation>
+        <translation>Nåværende draktnavn</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Pekerdrakt bruk i velkomstvindu</translation>
+        <translation>Pekerdrakt bruk i velkomstvindu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Brukeravatarmappe for hele systemet</translation>
+        <translation>Brukeravatarmappe for hele systemet</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Antall brukere å bruke som terskel</translation>
+        <translation>Antall brukere å bruke som terskel</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Forhåndsvis</translation>
+        <translation>Forhåndsvis</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Skru på visning av egendefinerte brukeravatarer</translation>
+        <translation>Skru på visning av egendefinerte brukeravatarer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Filene skal navngis &lt;brukernavn&gt;.face.icon</translation>
+        <translation>Filene skal navngis &lt;brukernavn&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Brukere</translation>
+        <translation>Brukere</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Forvalgt $PATH for innloggede brukere</translation>
+        <translation>Forvalgt $PATH for innloggede brukere</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ med mindre de skrus på spesifikt med EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Kommainndelt liste over brukere som ikke skal opplistes</translation>
+        <translation>Kommainndelt liste over brukere som ikke skal opplistes</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Minste bruker-ID for viste brukere</translation>
+        <translation>Minste bruker-ID for viste brukere</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Maksimal bruker-ID for viste brukere</translation>
+        <translation>Maksimal bruker-ID for viste brukere</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Husk normal økt for sist innloggede bruker</translation>
+        <translation>Husk normal økt for sist innloggede bruker</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Husk sist innloggede bruker (med normal økt)</translation>
+        <translation>Husk sist innloggede bruker (med normal økt)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Skru på Qt sin automatiske høy-DPI-skalering</translation>
+        <translation>Skru på Qt sin automatiske høy-DPI-skalering</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Sti til et skript å kjøre ved oppstart av skrivebordet</translation>
+        <translation>Sti til et skript å kjøre ved oppstart av skrivebordet</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Sti til brukerøkt-loggfil</translation>
+        <translation>Sti til brukerøkt-loggfil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Mappe inneholdende Wayland-økter</translation>
+        <translation>Mappe inneholdende Wayland-økter</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ med mindre de skrus på spesifikt med EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Sti til X-tjenerbinærfil</translation>
+        <translation>Sti til X-tjenerbinærfil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumenter sendt til X-tjenerkall</translation>
+        <translation>Argumenter sendt til X-tjenerkall</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Mappe inneholdende tilgjengelige X-økter</translation>
+        <translation>Mappe inneholdende tilgjengelige X-økter</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Sti til skript å kjøre ved oppstart av skjermtjeneren</translation>
+        <translation>Sti til skript å kjøre ved oppstart av skjermtjeneren</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Sti til skript å kjøre ved stopping av skjermtjeneren</translation>
+        <translation>Sti til skript å kjøre ved stopping av skjermtjeneren</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Sti til xauth-binærfil</translation>
+        <translation>Sti til xauth-binærfil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Sti til Xephyr-binærfil</translation>
+        <translation>Sti til Xephyr-binærfil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Sti til Xauthority-fil</translation>
+        <translation>Sti til Xauthority-fil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Fil</translation>
+        <translation>Fil</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ med mindre de skrus på spesifikt med EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM-oppsettsredigerer</translation>
+        <translation>SDDM-oppsettsredigerer</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_nl.ts
+++ b/resources/translations/sddm-conf_nl.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatisch aanmelden</translation>
+        <translation>Automatisch aanmelden</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Gebruikersnaam bij automatische aanmeldsessie</translation>
+        <translation>Gebruikersnaam bij automatische aanmeldsessie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Geef aan of sddm automatisch sessies moet aanmelden nadat ze zijn afgesloten</translation>
+        <translation>Geef aan of sddm automatisch sessies moet aanmelden nadat ze zijn afgesloten</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Naam van sessiebestand voor automatisch aanmelden (probeer recentste aanmelding indien blanco)</translation>
+        <translation>Naam van sessiebestand voor automatisch aanmelden (probeer recentste aanmelding indien blanco)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Algemeen</translation>
+        <translation>Algemeen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Herstartopdracht</translation>
+        <translation>Herstartopdracht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">&apos;none&apos; = NumLock wordt niet aan- of uitgezet
+        <translation>&apos;none&apos; = NumLock wordt niet aan- of uitgezet
 LET OP: dit wordt momenteel genegeerd als automatisch aanmelden is ingeschakeld.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">De initiële NumLock-status: on, off of none.</translation>
+        <translation>De initiële NumLock-status: on, off of none.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Invoermethodemodule</translation>
+        <translation>Invoermethodemodule</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Afbreekopdracht</translation>
+        <translation>Afbreekopdracht</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Thema</translation>
+        <translation>Thema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Themamaplocatie</translation>
+        <translation>Themamaplocatie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">daarboven worden gebruikersafbeeldingen uitgeschakeld,
+        <translation>daarboven worden gebruikersafbeeldingen uitgeschakeld,
 tenzij expliciet ingeschakeld middels EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Naam van huidig thema</translation>
+        <translation>Naam van huidig thema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Cursorthema op aanmeldscherm</translation>
+        <translation>Cursorthema op aanmeldscherm</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Algemene map met gebruikersafbeeldingen</translation>
+        <translation>Algemene map met gebruikersafbeeldingen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Aantal gebruikers (drempelwaarde)</translation>
+        <translation>Aantal gebruikers (drempelwaarde)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Voorvertoning</translation>
+        <translation>Voorvertoning</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Aangepaste gebruikersafbeeldingen tonen</translation>
+        <translation>Aangepaste gebruikersafbeeldingen tonen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">De bestanden moeten de naam &lt;gebruikersnaam&gt;.face.icon dragen</translation>
+        <translation>De bestanden moeten de naam &lt;gebruikersnaam&gt;.face.icon dragen</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Gebruikers</translation>
+        <translation>Gebruikers</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Standaard $PAD van aangemelde gebruikers</translation>
+        <translation>Standaard $PAD van aangemelde gebruikers</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ tenzij expliciet ingeschakeld middels EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Een kommagescheiden lijst met gebruikers niet moeten worden toegevoegd aan de lijst</translation>
+        <translation>Een kommagescheiden lijst met gebruikers niet moeten worden toegevoegd aan de lijst</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Minimale gebruikersid van getoonde gebruikers</translation>
+        <translation>Minimale gebruikersid van getoonde gebruikers</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Maximale gebruikersid van getoonde gebruikers</translation>
+        <translation>Maximale gebruikersid van getoonde gebruikers</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Sessie van laatst aangemelde gebruiker onthouden</translation>
+        <translation>Sessie van laatst aangemelde gebruiker onthouden</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Sessie van laatst aangemelde gebruiker onthouden</translation>
+        <translation>Sessie van laatst aangemelde gebruiker onthouden</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Automatisch schalen op schermen met hoge dpi&apos;s</translation>
+        <translation>Automatisch schalen op schermen met hoge dpi&apos;s</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Locatie van uit te voeren script bij aanmelden</translation>
+        <translation>Locatie van uit te voeren script bij aanmelden</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Locatie van het gebruikerslogbestand</translation>
+        <translation>Locatie van het gebruikerslogbestand</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Map met beschikbare Wayland-sessies</translation>
+        <translation>Map met beschikbare Wayland-sessies</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ tenzij expliciet ingeschakeld middels EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Locatie van uitvoerbaar bestand van X-server</translation>
+        <translation>Locatie van uitvoerbaar bestand van X-server</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Opdrachtregelopties voor de X-server</translation>
+        <translation>Opdrachtregelopties voor de X-server</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Map met beschikbare X-sessies</translation>
+        <translation>Map met beschikbare X-sessies</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Locatie van uit te voeren script bij starten van ‘display server’</translation>
+        <translation>Locatie van uit te voeren script bij starten van ‘display server’</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Locatie van uit te voeren script bij stoppen van ‘display server’</translation>
+        <translation>Locatie van uit te voeren script bij stoppen van ‘display server’</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Locatie van uitvoerbaar bestand van xauth</translation>
+        <translation>Locatie van uitvoerbaar bestand van xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Locatie van uitvoerbaar bestand van Xephyr</translation>
+        <translation>Locatie van uitvoerbaar bestand van Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Locatie van het Xauthority-bestand</translation>
+        <translation>Locatie van het Xauthority-bestand</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Bestand</translation>
+        <translation>Bestand</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ tenzij expliciet ingeschakeld middels EnableAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM-configuratiebewerker</translation>
+        <translation>SDDM-configuratiebewerker</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_pt.ts
+++ b/resources/translations/sddm-conf_pt.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Iniciar sessão automaticamente</translation>
+        <translation>Iniciar sessão automaticamente</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Nome de utilizar para iniciar sessão</translation>
+        <translation>Nome de utilizar para iniciar sessão</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Se sddm deve iniciar automaticamente a sessão depois de sair</translation>
+        <translation>Se sddm deve iniciar automaticamente a sessão depois de sair</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Nome do ficheiro de sessão para início automático (se vazio, tenta o último acesso)</translation>
+        <translation>Nome do ficheiro de sessão para início automático (se vazio, tenta o último acesso)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Comando Reiniciar</translation>
+        <translation>Comando Reiniciar</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Se a propriedade estiver definida para &apos;none&apos;, o estado não será alterado.
+        <translation>Se a propriedade estiver definida para &apos;none&apos;, o estado não será alterado.
 NOTA: esta propriedade é ignorada se a sessão iniciar autenticamente.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Estado NumLock inicial. Pode estar ativo, inativo ou nenhum deles.</translation>
+        <translation>Estado NumLock inicial. Pode estar ativo, inativo ou nenhum deles.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Módulo do método de introdução</translation>
+        <translation>Módulo do método de introdução</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Comando Suspender</translation>
+        <translation>Comando Suspender</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Tema</translation>
+        <translation>Tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Caminho do diretório do tema</translation>
+        <translation>Caminho do diretório do tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">acima do qual os &apos;avatars&apos; estão desativados
+        <translation>acima do qual os &apos;avatars&apos; estão desativados
 a menos que explicitamente definidos em &apos;EnableAvatars&apos;</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Nome do tema atual</translation>
+        <translation>Nome do tema atual</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Tema de cursor utilizado no ecrã</translation>
+        <translation>Tema de cursor utilizado no ecrã</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Diretório genérico para os &apos;avatars&apos;</translation>
+        <translation>Diretório genérico para os &apos;avatars&apos;</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Número máximo de utilizadores mostrados</translation>
+        <translation>Número máximo de utilizadores mostrados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Pré-visualização</translation>
+        <translation>Pré-visualização</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Ativar exibição de &apos;avatars&apos; personalizados</translation>
+        <translation>Ativar exibição de &apos;avatars&apos; personalizados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Os ficheiros devem ter o nome &lt;nomedeutilizador&gt;.face.icon</translation>
+        <translation>Os ficheiros devem ter o nome &lt;nomedeutilizador&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Utilizadores</translation>
+        <translation>Utilizadores</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">$PATH padrão para os utilizadores com sessão iniciada</translation>
+        <translation>$PATH padrão para os utilizadores com sessão iniciada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ a menos que explicitamente definidos em &apos;EnableAvatars&apos;</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Lista separada por vírgulas de utilizadores que não devem ser listados</translation>
+        <translation>Lista separada por vírgulas de utilizadores que não devem ser listados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">ID de utilizador mínimo para os utilizadores mostrados</translation>
+        <translation>ID de utilizador mínimo para os utilizadores mostrados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">ID de utilizador máximo para os utilizadores mostrados</translation>
+        <translation>ID de utilizador máximo para os utilizadores mostrados</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Memorizar sessão do último utilizador com sessão iniciada</translation>
+        <translation>Memorizar sessão do último utilizador com sessão iniciada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Memorizar último utilizador com sessão iniciada</translation>
+        <translation>Memorizar último utilizador com sessão iniciada</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Ativar ajuste Qt para High-DPI</translation>
+        <translation>Ativar ajuste Qt para High-DPI</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Caminho para o script a executar ao iniciar a sessão</translation>
+        <translation>Caminho para o script a executar ao iniciar a sessão</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Caminho para o ficheiro de registos do utilizador</translation>
+        <translation>Caminho para o ficheiro de registos do utilizador</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Diretório que contém as sessões Wayland disponíveis</translation>
+        <translation>Diretório que contém as sessões Wayland disponíveis</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ a menos que explicitamente definidos em &apos;EnableAvatars&apos;</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Caminho para o binário do servidor X</translation>
+        <translation>Caminho para o binário do servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumentos enviados para invocar o servidor X</translation>
+        <translation>Argumentos enviados para invocar o servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Diretório que contém as sessões X disponíveis</translation>
+        <translation>Diretório que contém as sessões X disponíveis</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Caminho para o script a executar ao iniciar a servidor X</translation>
+        <translation>Caminho para o script a executar ao iniciar a servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Caminho para o script a executar ao parar o servidor X</translation>
+        <translation>Caminho para o script a executar ao parar o servidor X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Caminho para o binário &apos;xauth&apos;</translation>
+        <translation>Caminho para o binário &apos;xauth&apos;</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Caminho para o binário &apos;Xephyr&apos;</translation>
+        <translation>Caminho para o binário &apos;Xephyr&apos;</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Caminho para o ficheiro &apos;Xauthority&apos;</translation>
+        <translation>Caminho para o ficheiro &apos;Xauthority&apos;</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Ficheiro</translation>
+        <translation>Ficheiro</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ a menos que explicitamente definidos em &apos;EnableAvatars&apos;</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Editor de configurações de SDDM</translation>
+        <translation>Editor de configurações de SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_ru.ts
+++ b/resources/translations/sddm-conf_ru.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Автовход</translation>
+        <translation>Автовход</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Имя пользователя для автоматического входа</translation>
+        <translation>Имя пользователя для автоматического входа</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Автоматически входить в сеансы после выхода</translation>
+        <translation>Автоматически входить в сеансы после выхода</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Название файла сеанса для автоматического входа</translation>
+        <translation>Название файла сеанса для автоматического входа</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Общие</translation>
+        <translation>Общие</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Команда перезагрузки</translation>
+        <translation>Команда перезагрузки</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Если параметр имеет значение ничего, numlock не будет изменен
+        <translation>Если параметр имеет значение ничего, numlock не будет изменен
 Примечание: В настоящее время игнорируется, если включен автовход.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Начальное состояние NumLock. Может быть включен, выключен или ничего.</translation>
+        <translation>Начальное состояние NumLock. Может быть включен, выключен или ничего.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Модуль метода ввода</translation>
+        <translation>Модуль метода ввода</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Команда выключения</translation>
+        <translation>Команда выключения</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Тема</translation>
+        <translation>Тема</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Путь к каталогу с темами</translation>
+        <translation>Путь к каталогу с темами</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">выше которого аватары отключены,
+        <translation>выше которого аватары отключены,
 если явно не разрешено с Включить аватары</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Название текущей темы</translation>
+        <translation>Название текущей темы</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Тема курсора, используемая в приветствии</translation>
+        <translation>Тема курсора, используемая в приветствии</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Глобальный каталог пользовательских аватаров</translation>
+        <translation>Глобальный каталог пользовательских аватаров</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Пороговое значение количества пользователей</translation>
+        <translation>Пороговое значение количества пользователей</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Предпросмотр</translation>
+        <translation>Предпросмотр</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Включить отображение аватаров пользователей</translation>
+        <translation>Включить отображение аватаров пользователей</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Файлы должны называться &lt;имя_пользователя&gt;.face.icon</translation>
+        <translation>Файлы должны называться &lt;имя_пользователя&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Пользователи</translation>
+        <translation>Пользователи</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">$PATH по умолчанию для зарегистрированных пользователей</translation>
+        <translation>$PATH по умолчанию для зарегистрированных пользователей</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Список пользователей через запятые, которые не будут отображаться</translation>
+        <translation>Список пользователей через запятые, которые не будут отображаться</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Минимальный идентификатор пользователя для отображаемых пользователей</translation>
+        <translation>Минимальный идентификатор пользователя для отображаемых пользователей</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Максимальный идентификатор пользователя для отображаемых пользователей</translation>
+        <translation>Максимальный идентификатор пользователя для отображаемых пользователей</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Запоминать сеанс последнего успешно зарегистрированного пользователя</translation>
+        <translation>Запоминать сеанс последнего успешно зарегистрированного пользователя</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Запоминать последнего успешно зарегистрированного пользователя</translation>
+        <translation>Запоминать последнего успешно зарегистрированного пользователя</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Автомасштабирование для экранов с высоким разрешением (HiDPI)</translation>
+        <translation>Автомасштабирование для экранов с высоким разрешением (HiDPI)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Путь к сценарию, выполняемому при запуске сеанса рабочего стола</translation>
+        <translation>Путь к сценарию, выполняемому при запуске сеанса рабочего стола</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Путь к файлу журнала сеанса пользователя</translation>
+        <translation>Путь к файлу журнала сеанса пользователя</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Каталог, содержащий доступные сеансы Wayland</translation>
+        <translation>Каталог, содержащий доступные сеансы Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Путь до двоичного файла X server</translation>
+        <translation>Путь до двоичного файла X server</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Аргументы, переданные вызову X-сервера</translation>
+        <translation>Аргументы, переданные вызову X-сервера</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Каталог, содержащий доступные сеансы X</translation>
+        <translation>Каталог, содержащий доступные сеансы X</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Путь к сценарию, выполняемому при запуске сервера дисплея</translation>
+        <translation>Путь к сценарию, выполняемому при запуске сервера дисплея</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Путь к сценарию, выполняемому при остановке сервера дисплея</translation>
+        <translation>Путь к сценарию, выполняемому при остановке сервера дисплея</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Путь до двоичного файла xauth</translation>
+        <translation>Путь до двоичного файла xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Путь до двоичного файла Xephyr</translation>
+        <translation>Путь до двоичного файла Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Путь к файлу Xauthority</translation>
+        <translation>Путь к файлу Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Файл</translation>
+        <translation>Файл</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Редактор конфигурации SDDM</translation>
+        <translation>Редактор конфигурации SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_sk.ts
+++ b/resources/translations/sddm-conf_sk.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Automatické prihlásenie</translation>
+        <translation>Automatické prihlásenie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Používateľské meno pre automatické prihlásenie</translation>
+        <translation>Používateľské meno pre automatické prihlásenie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Nastaviť automatické prihlásenie do relácií po ich skončení</translation>
+        <translation>Nastaviť automatické prihlásenie do relácií po ich skončení</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Názov súboru relácie pre automatické prihlásenie relácie (ak je pole prázdne, program skúsi posledné prihlásenie)</translation>
+        <translation>Názov súboru relácie pre automatické prihlásenie relácie (ak je pole prázdne, program skúsi posledné prihlásenie)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Všeobecné</translation>
+        <translation>Všeobecné</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Príkaz na reštart</translation>
+        <translation>Príkaz na reštart</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Ak hodnotu nastavíte na &apos;bez zmeny&apos;, stav numerickej klávesnice sa nezmení
+        <translation>Ak hodnotu nastavíte na &apos;bez zmeny&apos;, stav numerickej klávesnice sa nezmení
 POZN.: Toto nastavenie je momentálne ignorované pri zapnutí automatického prihlásenia.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Počiatočný stav NumLock. Zapnúť, vypnúť alebo bez zmeny.</translation>
+        <translation>Počiatočný stav NumLock. Zapnúť, vypnúť alebo bez zmeny.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Modul vstupnej metódy</translation>
+        <translation>Modul vstupnej metódy</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Príkaz pre zastavenie</translation>
+        <translation>Príkaz pre zastavenie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Téma</translation>
+        <translation>Téma</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Cesta k priečinku s témami vzhľadu</translation>
+        <translation>Cesta k priečinku s témami vzhľadu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">po jeho prekročení sa vypne funkcia avatarov
+        <translation>po jeho prekročení sa vypne funkcia avatarov
 ak nie je výslovne povolená pomocou EnabeAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Súčasná téma</translation>
+        <translation>Súčasná téma</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Vzhľad kurzora na uvítacej obrazovke</translation>
+        <translation>Vzhľad kurzora na uvítacej obrazovke</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Globálny priečinok pre avatary používateľov</translation>
+        <translation>Globálny priečinok pre avatary používateľov</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Limit používateľov</translation>
+        <translation>Limit používateľov</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Náhľad</translation>
+        <translation>Náhľad</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Povoliť zobrazenie vlastných avatarov</translation>
+        <translation>Povoliť zobrazenie vlastných avatarov</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Tieto súbory by ste mali nazvať &lt;meno_používateľa&gt;.face.icon</translation>
+        <translation>Tieto súbory by ste mali nazvať &lt;meno_používateľa&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Používatelia</translation>
+        <translation>Používatelia</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Predvolená premenná $PATH pre prihlásených používateľov</translation>
+        <translation>Predvolená premenná $PATH pre prihlásených používateľov</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ ak nie je výslovne povolená pomocou EnabeAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Čiarkou oddelený zoznam používateľov, ktorí nemajú byť vypísaní</translation>
+        <translation>Čiarkou oddelený zoznam používateľov, ktorí nemajú byť vypísaní</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Minimálne ID používateľa zobrazených používateľov</translation>
+        <translation>Minimálne ID používateľa zobrazených používateľov</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Maximálne ID používateľa zobrazených používateľov</translation>
+        <translation>Maximálne ID používateľa zobrazených používateľov</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Pamätať si reláciu naposledy prihláseného používateľa</translation>
+        <translation>Pamätať si reláciu naposledy prihláseného používateľa</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Pamätať si naposledy prihláseného používateľa</translation>
+        <translation>Pamätať si naposledy prihláseného používateľa</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Povoliť automatickú úpravu DPI</translation>
+        <translation>Povoliť automatickú úpravu DPI</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Cesta k skriptu, ktorý sa vykoná pri spustení relácie</translation>
+        <translation>Cesta k skriptu, ktorý sa vykoná pri spustení relácie</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Cesta k používateľskému logu</translation>
+        <translation>Cesta k používateľskému logu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Priečinok s dostupnými Wayland reláciami</translation>
+        <translation>Priečinok s dostupnými Wayland reláciami</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ ak nie je výslovne povolená pomocou EnabeAvatars</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Cesta k spustiteľnému súboru x servera</translation>
+        <translation>Cesta k spustiteľnému súboru x servera</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Argumenty odovzdané pri volaní X serveru</translation>
+        <translation>Argumenty odovzdané pri volaní X serveru</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Priečinok s dostupnými X reláciami</translation>
+        <translation>Priečinok s dostupnými X reláciami</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Cesta ku skriptu, ktorý sa vykoná pri spustení zobrazovacieho servera</translation>
+        <translation>Cesta ku skriptu, ktorý sa vykoná pri spustení zobrazovacieho servera</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Cesta ku skriptu, ktorý sa vykoná pri zastavení zobrazovacieho servera</translation>
+        <translation>Cesta ku skriptu, ktorý sa vykoná pri zastavení zobrazovacieho servera</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Cesta k spúšťateľnému súboru xauth</translation>
+        <translation>Cesta k spúšťateľnému súboru xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Cesta k spúšťateľnému súboru Xephyr</translation>
+        <translation>Cesta k spúšťateľnému súboru Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Cesta k súboru Xauthority</translation>
+        <translation>Cesta k súboru Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Súbor</translation>
+        <translation>Súbor</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ ak nie je výslovne povolená pomocou EnabeAvatars</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Nastavenia SDDM</translation>
+        <translation>Nastavenia SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_tr.ts
+++ b/resources/translations/sddm-conf_tr.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Otomatik giriş</translation>
+        <translation>Otomatik giriş</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Otomatik oturum açmak için kullanıcı adı</translation>
+        <translation>Otomatik oturum açmak için kullanıcı adı</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Oturumdan çıkıldığında sddm otomatik olarak yeniden giriş yapsın mı</translation>
+        <translation>Oturumdan çıkıldığında sddm otomatik olarak yeniden giriş yapsın mı</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Otomatik oturum açmak için oturum dosyasının adı (boşsa son oturum açılacak)</translation>
+        <translation>Otomatik oturum açmak için oturum dosyasının adı (boşsa son oturum açılacak)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Genel</translation>
+        <translation>Genel</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Yeniden başlatma komutu</translation>
+        <translation>Yeniden başlatma komutu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Özellik yok olarak ayarlanırsa sayı kilidi değiştirilmez
+        <translation>Özellik yok olarak ayarlanırsa sayı kilidi değiştirilmez
 NOT: Otomatik oturum açma etkinse şu anda yok sayılır.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Başta NumLock durumu. Açık, kapalı veya hiçbiri olabilir.</translation>
+        <translation>Başta NumLock durumu. Açık, kapalı veya hiçbiri olabilir.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Giriş yöntemi modülü</translation>
+        <translation>Giriş yöntemi modülü</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Kapatma komutu</translation>
+        <translation>Kapatma komutu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Tema</translation>
+        <translation>Tema</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Tema dizini yolu</translation>
+        <translation>Tema dizini yolu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">EnableAvatars ile açıkça etkinleştirilmediği sürece 
+        <translation>EnableAvatars ile açıkça etkinleştirilmediği sürece 
 hangi avatarların devre dışı bırakıldığı</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Aktif tema adı</translation>
+        <translation>Aktif tema adı</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Karşılayıcıda kullanılan imleç teması</translation>
+        <translation>Karşılayıcıda kullanılan imleç teması</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Kullanıcı avatarları için global dizin</translation>
+        <translation>Kullanıcı avatarları için global dizin</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Eşik olarak kullanılacak kullanıcı sayısı</translation>
+        <translation>Eşik olarak kullanılacak kullanıcı sayısı</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Önizleme</translation>
+        <translation>Önizleme</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Özel kullanıcı avatarlarının görüntülenmesini etkinleştirin</translation>
+        <translation>Özel kullanıcı avatarlarının görüntülenmesini etkinleştirin</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Dosyalar kullanıcı adı face.icon olarak adlandırılmalıdır</translation>
+        <translation>Dosyalar kullanıcı adı face.icon olarak adlandırılmalıdır</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Kullanıcılar</translation>
+        <translation>Kullanıcılar</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Giriş yapan kullanıcılar için varsayılan $PATH</translation>
+        <translation>Giriş yapan kullanıcılar için varsayılan $PATH</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ hangi avatarların devre dışı bırakıldığı</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Listelenmemesi gereken kullanıcıların virgülle ayrılmış listesi</translation>
+        <translation>Listelenmemesi gereken kullanıcıların virgülle ayrılmış listesi</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Görüntülenen kullanıcılar için minimum kullanıcı kimliği</translation>
+        <translation>Görüntülenen kullanıcılar için minimum kullanıcı kimliği</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Görüntülenen kullanıcılar için maksimum kullanıcı kimliği</translation>
+        <translation>Görüntülenen kullanıcılar için maksimum kullanıcı kimliği</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Başarıyla oturum açan son kullanıcının oturumunu hatırla</translation>
+        <translation>Başarıyla oturum açan son kullanıcının oturumunu hatırla</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Başarıyla giriş yapan son kullanıcıyı hatırla</translation>
+        <translation>Başarıyla giriş yapan son kullanıcıyı hatırla</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Qt&apos;nin otomatik yüksek DPI ölçeklendirmesini etkinleştir</translation>
+        <translation>Qt&apos;nin otomatik yüksek DPI ölçeklendirmesini etkinleştir</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Masaüstü oturumu başlatılırken yürütülecek komut dosyasının yolu</translation>
+        <translation>Masaüstü oturumu başlatılırken yürütülecek komut dosyasının yolu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Kullanıcı oturumu günlük dosyasının yolu</translation>
+        <translation>Kullanıcı oturumu günlük dosyasının yolu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Mevcut Wayland oturumlarını içeren dizin</translation>
+        <translation>Mevcut Wayland oturumlarını içeren dizin</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ hangi avatarların devre dışı bırakıldığı</translation>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">X sunucusu ikili dosyasına giden yol</translation>
+        <translation>X sunucusu ikili dosyasına giden yol</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">X sunucusu çağrısına aktarılan bağımsız değişkenler</translation>
+        <translation>X sunucusu çağrısına aktarılan bağımsız değişkenler</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Mevcut X oturumlarını içeren dizin</translation>
+        <translation>Mevcut X oturumlarını içeren dizin</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Görüntü sunucusunu başlatırken yürütülecek komut dosyasının yolu</translation>
+        <translation>Görüntü sunucusunu başlatırken yürütülecek komut dosyasının yolu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Görüntü sunucusu durdurulduğunda yürütülecek komut dosyasının yolu</translation>
+        <translation>Görüntü sunucusu durdurulduğunda yürütülecek komut dosyasının yolu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Xauth ikili dosyasına giden yol</translation>
+        <translation>Xauth ikili dosyasına giden yol</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Xephyr ikili dosyasına giden yol</translation>
+        <translation>Xephyr ikili dosyasına giden yol</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Xauthority dosyasının yolu</translation>
+        <translation>Xauthority dosyasının yolu</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Dosya</translation>
+        <translation>Dosya</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ hangi avatarların devre dışı bırakıldığı</translation>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM Ayar Düzenleyicisi</translation>
+        <translation>SDDM Ayar Düzenleyicisi</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_uk.ts
+++ b/resources/translations/sddm-conf_uk.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">Автоматичний вхід</translation>
+        <translation>Автоматичний вхід</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">Ім&apos;я користувача для автоматичного входу в сеанс</translation>
+        <translation>Ім&apos;я користувача для автоматичного входу в сеанс</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">Чи повинен sddm автоматично входити в сеанси після виходу з них</translation>
+        <translation>Чи повинен sddm автоматично входити в сеанси після виходу з них</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">Назва файлу сеансу для автоматичного входу (якщо не вказано, спробувати останній вхід)</translation>
+        <translation>Назва файлу сеансу для автоматичного входу (якщо не вказано, спробувати останній вхід)</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">Загальні</translation>
+        <translation>Загальні</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">Команда для перезавантаження</translation>
+        <translation>Команда для перезавантаження</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">Якщо встановлено значення none, NumLock не змінюється
+        <translation>Якщо встановлено значення none, NumLock не змінюється
 ПРИМІТКА: ігнорується, якщо ввімкнено автоматичний вхід.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">Початковий стан NumLock. Може бути on, off або none.</translation>
+        <translation>Початковий стан NumLock. Може бути on, off або none.</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">Модуль способу введення</translation>
+        <translation>Модуль способу введення</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">Припинити команду</translation>
+        <translation>Припинити команду</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">Тема</translation>
+        <translation>Тема</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">Шлях до теки тем</translation>
+        <translation>Шлях до теки тем</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">які користувацькі зображення буде вимкнено,
+        <translation>які користувацькі зображення буде вимкнено,
 якщо явно не ввімкнено опцією EnableAvatars</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">Назва поточної теми</translation>
+        <translation>Назва поточної теми</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">Тема курсору для використання у greeter</translation>
+        <translation>Тема курсору для використання у greeter</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">Загальна тека для користувацьких зображень</translation>
+        <translation>Загальна тека для користувацьких зображень</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">Обмеження кількості користувачів</translation>
+        <translation>Обмеження кількості користувачів</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">Попередній перегляд</translation>
+        <translation>Попередній перегляд</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">Увімкнути показ користувацьких зображень</translation>
+        <translation>Увімкнути показ користувацьких зображень</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">Файли повинні мати назву &lt;ім&apos;я_користувача&gt;.face.icon</translation>
+        <translation>Файли повинні мати назву &lt;ім&apos;я_користувача&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">Користувачі</translation>
+        <translation>Користувачі</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">Типовий $PATH для користувачів, які увійшли</translation>
+        <translation>Типовий $PATH для користувачів, які увійшли</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">Перелік користувачів, яких не має бути в переліку, розділений комами</translation>
+        <translation>Перелік користувачів, яких не має бути в переліку, розділений комами</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">Мінімально можливий UID для показаних користувачів</translation>
+        <translation>Мінімально можливий UID для показаних користувачів</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">Максимально можливий UID для показаних користувачів</translation>
+        <translation>Максимально можливий UID для показаних користувачів</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">Пам’ятати сеанс останнього користувача, який успішно зайшов</translation>
+        <translation>Пам’ятати сеанс останнього користувача, який успішно зайшов</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">Пам’ятати останнього користувача, який успішно зайшов у сеанс</translation>
+        <translation>Пам’ятати останнього користувача, який успішно зайшов у сеанс</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">Увімкнути автоматичне масштабування Qt з високою роздільною здатністю</translation>
+        <translation>Увімкнути автоматичне масштабування Qt з високою роздільною здатністю</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">Шлях до сценарію для виконання під час запуску стільниці</translation>
+        <translation>Шлях до сценарію для виконання під час запуску стільниці</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">Шлях до файлу журналу сеансу користувача</translation>
+        <translation>Шлях до файлу журналу сеансу користувача</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">Тека, що містить доступні сеанси Wayland</translation>
+        <translation>Тека, що містить доступні сеанси Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">Шлях до виконуваного файлу X сервера</translation>
+        <translation>Шлях до виконуваного файлу X сервера</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">Аргументи, передані для виклику X сервера</translation>
+        <translation>Аргументи, передані для виклику X сервера</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">Каталог з файлами доступних X-сеансів</translation>
+        <translation>Каталог з файлами доступних X-сеансів</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">Шлях до сценарію для виконання під час запуску сервера відображення</translation>
+        <translation>Шлях до сценарію для виконання під час запуску сервера відображення</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">Шлях до сценарію для виконання під час зупинки сервера відображення</translation>
+        <translation>Шлях до сценарію для виконання під час зупинки сервера відображення</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">Шлях до виконуваного файлу xauth</translation>
+        <translation>Шлях до виконуваного файлу xauth</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Шлях до виконуваного файлу Xephyr</translation>
+        <translation>Шлях до виконуваного файлу Xephyr</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">Шлях до файлу Xauthority</translation>
+        <translation>Шлях до файлу Xauthority</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">Файл</translation>
+        <translation>Файл</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">Редактор налаштувань SDDM</translation>
+        <translation>Редактор налаштувань SDDM</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>

--- a/resources/translations/sddm-conf_zh_CN.ts
+++ b/resources/translations/sddm-conf_zh_CN.ts
@@ -6,116 +6,116 @@
     <message>
         <location filename="../../src/maindialog.ui" line="40"/>
         <source>Autologin</source>
-        <translation type="unfinished">自动登录</translation>
+        <translation>自动登录</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="61"/>
         <source>Username for autologin session</source>
-        <translation type="unfinished">自动登录会话的用户名</translation>
+        <translation>自动登录会话的用户名</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="71"/>
         <source>Whether sddm should automatically log back into sessions when they exit</source>
-        <translation type="unfinished">sddm 是否应在会话退出时自动重新登录到会话</translation>
+        <translation>sddm 是否应在会话退出时自动重新登录到会话</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="84"/>
         <source>Name of session file for autologin session (if empty try last logged in)</source>
-        <translation type="unfinished">自动登录会话的会话文件名称（如果留空，则尝试使用上次登录时的）</translation>
+        <translation>自动登录会话的会话文件名称（如果留空，则尝试使用上次登录时的）</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="108"/>
         <source>General</source>
-        <translation type="unfinished">一般</translation>
+        <translation>一般</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="135"/>
         <source>Reboot command</source>
-        <translation type="unfinished">重启命令</translation>
+        <translation>重启命令</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="142"/>
         <source>If property is set to none, numlock won&apos;t be changed
 NOTE: Currently ignored if autologin is enabled.</source>
-        <translation type="unfinished">如果属性设置为无，则不会更改 numlock状态
+        <translation>如果属性设置为无，则不会更改 numlock状态
 注意：如果启用了自动登录，则当前被忽略。</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="172"/>
         <source>Initial NumLock state. Can be on, off or none.</source>
-        <translation type="unfinished">初始的数字键盘锁定状态。可以是打开，关闭或者空。</translation>
+        <translation>初始的数字键盘锁定状态。可以是打开，关闭或者空。</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="179"/>
         <source>Input method module</source>
-        <translation type="unfinished">输入法模块</translation>
+        <translation>输入法模块</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="186"/>
         <source>Halt command</source>
-        <translation type="unfinished">关机命令</translation>
+        <translation>关机命令</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="207"/>
         <source>Theme</source>
-        <translation type="unfinished">主题</translation>
+        <translation>主题</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="250"/>
         <source>Theme directory path</source>
-        <translation type="unfinished">主题目录</translation>
+        <translation>主题目录</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="257"/>
         <source>above which avatars are disabled
 unless explicitly enabled with EnableAvatars</source>
-        <translation type="unfinished">以上是禁用的头像
+        <translation>以上是禁用的头像
 除非显式启用使用EnableAvatars启用</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="265"/>
         <source>Current theme name</source>
-        <translation type="unfinished">当前主题名</translation>
+        <translation>当前主题名</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="272"/>
         <source>Cursor theme used in the greeter</source>
-        <translation type="unfinished">greeter 中使用的游标主题</translation>
+        <translation>greeter 中使用的游标主题</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="279"/>
         <source>Global directory for user avatars</source>
-        <translation type="unfinished">用户图标的全局目录</translation>
+        <translation>用户图标的全局目录</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="289"/>
         <source>Number of users to use as threshold</source>
-        <translation type="unfinished">要用作阈值的用户数</translation>
+        <translation>要用作阈值的用户数</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="302"/>
         <source>Preview</source>
-        <translation type="unfinished">预览</translation>
+        <translation>预览</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="309"/>
         <source>Enable display of custom user avatars</source>
-        <translation type="unfinished">启用自定义用户化的显示</translation>
+        <translation>启用自定义用户化的显示</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="316"/>
         <source>The files should be named &lt;username&gt;.face.icon</source>
-        <translation type="unfinished">这个文件应该命名为 &lt;username&gt;.face.icon</translation>
+        <translation>这个文件应该命名为 &lt;username&gt;.face.icon</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="324"/>
         <source>Users</source>
-        <translation type="unfinished">用户</translation>
+        <translation>用户</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="345"/>
         <source>Default $PATH for logged in users</source>
-        <translation type="unfinished">已登录用户的默认 $PATH</translation>
+        <translation>已登录用户的默认 $PATH</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="355"/>
@@ -125,60 +125,60 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="365"/>
         <source>Comma-separated list of users that should not be listed</source>
-        <translation type="unfinished">不应该被列出的用逗号分隔的用户列表</translation>
+        <translation>不应该被列出的用逗号分隔的用户列表</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="375"/>
         <source>Minimum user id for displayed users</source>
-        <translation type="unfinished">显示用户的最小用户 id</translation>
+        <translation>显示用户的最小用户 id</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="392"/>
         <source>Maximum user id for displayed users</source>
-        <translation type="unfinished">显示用户的最大用户 id</translation>
+        <translation>显示用户的最大用户 id</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="409"/>
         <source>Remember the session of the last successfully logged in user</source>
-        <translation type="unfinished">记住上次成功登录的用户的桌面</translation>
+        <translation>记住上次成功登录的用户的桌面</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="416"/>
         <source>Remember the last successfully logged in user</source>
-        <translation type="unfinished">记住上次成功登录的用户</translation>
+        <translation>记住上次成功登录的用户</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="424"/>
         <source>Wayland</source>
-        <translation type="unfinished">Wayland</translation>
+        <translation>Wayland</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="445"/>
         <location filename="../../src/maindialog.ui" line="565"/>
         <source>Enable Qt&apos;s automatic high-DPI scaling</source>
-        <translation type="unfinished">启用 Qt的高分辨率自动缩放功能</translation>
+        <translation>启用 Qt的高分辨率自动缩放功能</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="452"/>
         <location filename="../../src/maindialog.ui" line="676"/>
         <source>Path to a script to execute when starting the desktop session</source>
-        <translation type="unfinished">启动桌面会话时要执行的脚本路径</translation>
+        <translation>启动桌面会话时要执行的脚本路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="470"/>
         <location filename="../../src/maindialog.ui" line="740"/>
         <source>Path to the user session log file</source>
-        <translation type="unfinished">用户的会话日志文件路径</translation>
+        <translation>用户的会话日志文件路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="488"/>
         <source>Directory containing available Wayland sessions</source>
-        <translation type="unfinished">包含有效Wayland会话的目录</translation>
+        <translation>包含有效Wayland会话的目录</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="520"/>
         <source>X11</source>
-        <translation type="unfinished">X11</translation>
+        <translation>X11</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="572"/>
@@ -188,47 +188,47 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.ui" line="669"/>
         <source>Path to X server binary</source>
-        <translation type="unfinished">X 服务器二进制的路径</translation>
+        <translation>X 服务器二进制的路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="683"/>
         <source>Arguments passed to the X server invocation</source>
-        <translation type="unfinished">传递给 X 服务器调用的参数</translation>
+        <translation>传递给 X 服务器调用的参数</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="690"/>
         <source>Directory containing available X sessions</source>
-        <translation type="unfinished">包含可用 X 会话的目录</translation>
+        <translation>包含可用 X 会话的目录</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="697"/>
         <source>Path to a script to execute when starting the display server</source>
-        <translation type="unfinished">当启动显示服务时要执行的脚本的路径</translation>
+        <translation>当启动显示服务时要执行的脚本的路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="704"/>
         <source>Path to a script to execute when stopping the display server</source>
-        <translation type="unfinished">当停止显示服务时要执行的脚本的路径</translation>
+        <translation>当停止显示服务时要执行的脚本的路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="714"/>
         <source>Path to xauth binary</source>
-        <translation type="unfinished">X 的授权二进制路径</translation>
+        <translation>X 的授权二进制路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="721"/>
         <source>Path to Xephyr binary</source>
-        <translation type="unfinished">Xephyr的二进制文件路径</translation>
+        <translation>Xephyr的二进制文件路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="747"/>
         <source>Path to the Xauthority file</source>
-        <translation type="unfinished">X 的授权文件路径</translation>
+        <translation>X 的授权文件路径</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="759"/>
         <source>File</source>
-        <translation type="unfinished">设置文件</translation>
+        <translation>设置文件</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.ui" line="778"/>
@@ -238,7 +238,7 @@ unless explicitly enabled with EnableAvatars</source>
     <message>
         <location filename="../../src/maindialog.cpp" line="23"/>
         <source>SDDM Configuration Editor</source>
-        <translation type="unfinished">SDDM 设置工具</translation>
+        <translation>SDDM 设置工具</translation>
     </message>
     <message>
         <location filename="../../src/maindialog.cpp" line="61"/>


### PR DESCRIPTION
I imported all in weblate and  saw that this was needed. This happens  always with migration of existing translations.
https://translate.lxqt-project.org/projects/redtide/sddm-conf/