### PR TITLE
Fixed loading of translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,11 @@ set_property(SOURCE ${UI_SOURCE} PROPERTY SKIP_AUTOMOC ON)
     )
 #endif()
 
-target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE SDDM_CONF_VERSION="${CMAKE_PROJECT_VERSION}")
+target_compile_definitions(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        SDDM_CONF_VERSION="${CMAKE_PROJECT_VERSION}"
+        SDDM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/${CMAKE_PROJECT_NAME}"
+)
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -8,32 +8,12 @@
 #include <QFile>
 #include <QDir>
 #include <QLocale>
-#include <QStandardPaths>
+#include <QLibraryInfo>
 #include <QTranslator>
 
 Application::Application(int& argc, char** argv)
     : QApplication(argc, argv)
 {
-    // NOTE: the example on following link seems not working; manually locating (12/2021)
-    // https://doc.qt.io/qt-5/internationalization.html#example-basic-qt-modules
-    QTranslator qtTranslator;
-    const QString qtDataPath = QStandardPaths::locate(
-        QStandardPaths::GenericDataLocation, "qt/translations",
-        QStandardPaths::LocateDirectory);
-
-    if (qtTranslator.load(
-            QLocale(), QLatin1String("qtbase"), QLatin1String("_"), qtDataPath))
-        installTranslator(&qtTranslator);
-
-    QTranslator translator;
-    const QString appDataPath = QStandardPaths::locate(
-        QStandardPaths::GenericDataLocation, "sddm-conf/translations",
-        QStandardPaths::LocateDirectory);
-
-    if (translator.load(
-            QLocale(), QLatin1String("sddm-conf"), QLatin1String("_"), appDataPath))
-        installTranslator(&translator);
-
     // FIXME: The configuration file management is more complex,
     // this is just a temporary solution, see sddm.conf manual.
     QString path = QStringLiteral("/etc/sddm.conf");
@@ -50,6 +30,20 @@ Application::Application(int& argc, char** argv)
 int main(int argc, char* argv[])
 {
     Application app(argc, argv);
+
+    // Qt translations
+    QTranslator qtTranslator;
+    if (qtTranslator.load(QStringLiteral("qt_") + QLocale::system().name(),
+                          QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
+        app.installTranslator(&qtTranslator);
+    }
+    // app translations
+    QTranslator translator;
+    if (translator.load(QStringLiteral("sddm-conf_") + QLocale::system().name(),
+                        QStringLiteral(SDDM_DATA_DIR) + QStringLiteral("/translations"))) {
+        app.installTranslator(&translator);
+    }
+
     MainDialog w;
     w.show();
 


### PR DESCRIPTION
Translations should be installed after the app is constructed. Previously, they were installed inside c-tor and weren't loaded.

Fixes https://github.com/redtide/sddm-conf/issues/8